### PR TITLE
Phase 2: property photos and floorplans via Supabase Storage

### DIFF
--- a/Bold_Vision_CRM/src/components/base/PhotoUploader.vue
+++ b/Bold_Vision_CRM/src/components/base/PhotoUploader.vue
@@ -1,0 +1,196 @@
+<template>
+  <div>
+    <!-- Drop zone -->
+    <div
+      class="uploader-dropzone rounded-lg pa-4 mb-3 d-flex flex-column align-center justify-center"
+      :class="{ 'uploader-dropzone--active': isDraggingOver }"
+      @dragover.prevent="isDraggingOver = true"
+      @dragleave="isDraggingOver = false"
+      @drop.prevent="onFileDrop"
+      @click="fileInput.click()"
+    >
+      <v-icon size="36" color="grey-darken-1">mdi-cloud-upload-outline</v-icon>
+      <p class="text-body-2 text-grey-darken-1 mt-2 mb-0">
+        Drag & drop or <span class="text-primary">click to upload</span>
+      </p>
+      <input
+        ref="fileInput"
+        type="file"
+        :accept="accept"
+        :multiple="multiple"
+        style="display: none"
+        @change="onFileInputChange"
+      />
+    </div>
+
+    <!-- Preview grid -->
+    <div v-if="items.length" class="uploader-grid">
+      <div
+        v-for="(item, i) in items"
+        :key="item.id"
+        class="uploader-item"
+        :class="{
+          'uploader-item--dragging': dragFrom === i,
+          'uploader-item--over': dragOver === i,
+        }"
+        draggable="true"
+        @dragstart="onDragStart(i)"
+        @dragover.prevent="dragOver = i"
+        @drop.prevent="onItemDrop(i)"
+        @dragend="onDragEnd"
+      >
+        <v-img
+          :src="signedUrls[item.storagePath] || ''"
+          aspect-ratio="1"
+          cover
+          class="rounded"
+        >
+          <template #placeholder>
+            <div class="d-flex align-center justify-center fill-height">
+              <v-progress-circular indeterminate size="20" />
+            </div>
+          </template>
+        </v-img>
+
+        <v-btn
+          icon="mdi-close"
+          size="x-small"
+          color="error"
+          class="uploader-item__delete"
+          @click.stop="emit('remove', item.id)"
+        />
+        <v-btn
+          icon="mdi-star"
+          size="x-small"
+          :color="mainPhotoPath === item.storagePath ? 'amber-darken-1' : 'grey-lighten-1'"
+          class="uploader-item__main"
+          :title="mainPhotoPath === item.storagePath ? 'Main photo' : 'Set as main photo'"
+          @click.stop="emit('select', item.storagePath)"
+        />
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, reactive, watch, onUnmounted } from 'vue'
+import { getSignedUrl } from '../../services/mediaService'
+
+const props = defineProps({
+  items: { type: Array, default: () => [] },
+  kind: { type: String, default: 'photo' },
+  mainPhotoPath: { type: String, default: null },
+  accept: { type: String, default: 'image/jpeg,image/png,image/webp' },
+  multiple: { type: Boolean, default: true },
+})
+
+const emit = defineEmits(['add', 'remove', 'reorder', 'select'])
+
+const fileInput = ref(null)
+const isDraggingOver = ref(false)
+const dragFrom = ref(null)
+const dragOver = ref(null)
+
+// storagePath → signed URL mapping, populated lazily as items arrive
+const signedUrls = reactive({})
+
+async function resolveUrls(items) {
+  for (const item of items) {
+    if (item.storagePath && !signedUrls[item.storagePath]) {
+      try {
+        signedUrls[item.storagePath] = await getSignedUrl(item.storagePath, props.kind)
+      } catch {
+        signedUrls[item.storagePath] = ''
+      }
+    }
+  }
+}
+
+watch(() => props.items, resolveUrls, { immediate: true, deep: true })
+
+onUnmounted(() => {
+  // revoke any blob URLs created from local file previews
+  Object.values(signedUrls).forEach((url) => {
+    if (url?.startsWith('blob:')) URL.revokeObjectURL(url)
+  })
+})
+
+// ── file upload ────────────────────────────────────────────────
+
+function onFileDrop(e) {
+  isDraggingOver.value = false
+  const files = Array.from(e.dataTransfer.files).filter((f) => f.type.startsWith('image/'))
+  if (files.length) emit('add', files)
+}
+
+function onFileInputChange(e) {
+  const files = Array.from(e.target.files)
+  if (files.length) emit('add', files)
+  e.target.value = ''
+}
+
+// ── drag-to-reorder within grid ────────────────────────────────
+
+function onDragStart(index) {
+  dragFrom.value = index
+}
+
+function onItemDrop(toIndex) {
+  if (dragFrom.value === null || dragFrom.value === toIndex) return
+  const reordered = [...props.items]
+  const [moved] = reordered.splice(dragFrom.value, 1)
+  reordered.splice(toIndex, 0, moved)
+  emit('reorder', reordered.map((item) => item.id))
+}
+
+function onDragEnd() {
+  dragFrom.value = null
+  dragOver.value = null
+}
+</script>
+
+<style scoped>
+.uploader-dropzone {
+  border: 2px dashed #cbd5e1;
+  cursor: pointer;
+  transition: border-color 0.2s, background 0.2s;
+  min-height: 96px;
+}
+.uploader-dropzone--active {
+  border-color: #4f46e5;
+  background: #f0f0ff;
+}
+
+.uploader-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(100px, 1fr));
+  gap: 8px;
+}
+
+.uploader-item {
+  position: relative;
+  border-radius: 8px;
+  overflow: visible;
+  cursor: grab;
+  opacity: 1;
+  transition: opacity 0.15s;
+}
+.uploader-item--dragging {
+  opacity: 0.4;
+}
+.uploader-item--over {
+  outline: 2px solid #4f46e5;
+  border-radius: 8px;
+}
+
+.uploader-item__delete {
+  position: absolute;
+  top: -8px;
+  right: -8px;
+}
+.uploader-item__main {
+  position: absolute;
+  bottom: -8px;
+  right: -8px;
+}
+</style>

--- a/Bold_Vision_CRM/src/composables/useSignedUrl.js
+++ b/Bold_Vision_CRM/src/composables/useSignedUrl.js
@@ -1,0 +1,35 @@
+import { ref, watch, onUnmounted } from 'vue'
+import { getSignedUrl } from '../services/mediaService'
+
+export function useSignedUrl(storagePath, kind = 'photo') {
+  const url = ref(null)
+  const loading = ref(false)
+
+  let refreshTimer = null
+
+  async function fetchUrl(path) {
+    if (!path) {
+      url.value = null
+      return
+    }
+    loading.value = true
+    try {
+      url.value = await getSignedUrl(path, kind)
+      // Re-fetch 1 minute before the signed URL expires (TTL is 1 hour)
+      clearTimeout(refreshTimer)
+      refreshTimer = setTimeout(() => fetchUrl(path), 59 * 60 * 1000)
+    } finally {
+      loading.value = false
+    }
+  }
+
+  watch(
+    () => (typeof storagePath === 'string' ? storagePath : storagePath?.value),
+    (path) => fetchUrl(path),
+    { immediate: true },
+  )
+
+  onUnmounted(() => clearTimeout(refreshTimer))
+
+  return { url, loading }
+}

--- a/Bold_Vision_CRM/src/services/mediaService.js
+++ b/Bold_Vision_CRM/src/services/mediaService.js
@@ -1,0 +1,67 @@
+import { supabase } from './supabase'
+
+const BUCKET = { photo: 'property-photos', floorplan: 'property-floorplans' }
+const SIGNED_URL_TTL = 3600
+
+// Simple in-memory cache so repeated renders don't re-request the same URL.
+// Keys are storage paths; values are { url, expiresAt } where expiresAt is a JS timestamp.
+const urlCache = new Map()
+
+export async function uploadPropertyImage(propertyId, file, { kind = 'photo' } = {}) {
+  const { data: { user } } = await supabase.auth.getUser()
+  const ext = file.name.split('.').pop()
+  const path = `${user.id}/${propertyId}/${Date.now()}.${ext}`
+  const bucket = BUCKET[kind]
+
+  const { error: uploadError } = await supabase.storage.from(bucket).upload(path, file)
+  if (uploadError) throw uploadError
+
+  const { data, error } = await supabase
+    .from('property_photos')
+    .insert({ property_id: propertyId, kind, storage_path: path, sort_order: 0 })
+    .select()
+    .single()
+  if (error) throw error
+
+  return data
+}
+
+export async function deletePropertyImage(photoId) {
+  const { data: photo, error: fetchError } = await supabase
+    .from('property_photos')
+    .select('storage_path, kind')
+    .eq('id', photoId)
+    .single()
+  if (fetchError) throw fetchError
+
+  const { error: storageError } = await supabase.storage
+    .from(BUCKET[photo.kind])
+    .remove([photo.storage_path])
+  if (storageError) throw storageError
+
+  urlCache.delete(photo.storage_path)
+
+  const { error } = await supabase.from('property_photos').delete().eq('id', photoId)
+  if (error) throw error
+}
+
+export async function getSignedUrl(storagePath, kind = 'photo') {
+  const cached = urlCache.get(storagePath)
+  if (cached && cached.expiresAt > Date.now() + 60_000) return cached.url
+
+  const { data, error } = await supabase.storage
+    .from(BUCKET[kind])
+    .createSignedUrl(storagePath, SIGNED_URL_TTL)
+  if (error) throw error
+
+  urlCache.set(storagePath, { url: data.signedUrl, expiresAt: Date.now() + SIGNED_URL_TTL * 1000 })
+  return data.signedUrl
+}
+
+export async function reorderPhotos(orderedIds) {
+  await Promise.all(
+    orderedIds.map((id, index) =>
+      supabase.from('property_photos').update({ sort_order: index }).eq('id', id),
+    ),
+  )
+}

--- a/Bold_Vision_CRM/src/services/propertiesService.js
+++ b/Bold_Vision_CRM/src/services/propertiesService.js
@@ -40,7 +40,14 @@ function mapRowToProperty(row) {
     houseSizeSqm,
     houseSize: houseSizeSqm ? `${houseSizeSqm} m²` : '',
     mainPhoto: row.main_photo_path ?? null,
-    gallery: [],
+    photos: (row.property_photos ?? [])
+      .filter((p) => p.kind === 'photo')
+      .sort((a, b) => a.sort_order - b.sort_order)
+      .map((p) => ({ id: p.id, storagePath: p.storage_path, caption: p.caption })),
+    floorplans: (row.property_photos ?? [])
+      .filter((p) => p.kind === 'floorplan')
+      .sort((a, b) => a.sort_order - b.sort_order)
+      .map((p) => ({ id: p.id, storagePath: p.storage_path, caption: p.caption })),
     description: row.description ?? '',
     notes: row.notes ?? '',
     highlights: row.highlights ?? [],
@@ -101,7 +108,7 @@ export async function listProperties() {
 export async function getProperty(id) {
   const { data, error } = await supabase
     .from('properties')
-    .select('*')
+    .select('*, property_photos(*)')
     .eq('id', id)
     .single()
   if (error) throw error
@@ -121,7 +128,7 @@ export async function updateProperty(id, payload) {
     .from('properties')
     .update(row)
     .eq('id', id)
-    .select()
+    .select('*, property_photos(*)')
     .single()
   if (error) throw error
   return mapRowToProperty(data)

--- a/Bold_Vision_CRM/src/stores/propertyStore.js
+++ b/Bold_Vision_CRM/src/stores/propertyStore.js
@@ -6,6 +6,11 @@ import {
   updateProperty,
   deleteProperty,
 } from '../services/propertiesService'
+import {
+  uploadPropertyImage,
+  deletePropertyImage,
+  reorderPhotos as reorderPhotoRows,
+} from '../services/mediaService'
 import { computeBadge } from '../utils/property'
 
 export const usePropertyStore = defineStore('properties', {
@@ -94,6 +99,25 @@ export const usePropertyStore = defineStore('properties', {
         this.error = e.message
         throw e
       }
+    },
+
+    async uploadPhoto(propertyId, file, kind) {
+      await uploadPropertyImage(propertyId, file, { kind })
+      await this.fetchProperty(propertyId)
+    },
+
+    async removePhoto(propertyId, photoId) {
+      await deletePropertyImage(photoId)
+      await this.fetchProperty(propertyId)
+    },
+
+    async reorderPhotos(propertyId, orderedIds) {
+      await reorderPhotoRows(orderedIds)
+      await this.fetchProperty(propertyId)
+    },
+
+    async setMainPhoto(propertyId, storagePath) {
+      await this.updateProperty(propertyId, { mainPhoto: storagePath })
     },
   },
 })

--- a/Bold_Vision_CRM/src/views/PropertyDetailsView.vue
+++ b/Bold_Vision_CRM/src/views/PropertyDetailsView.vue
@@ -33,9 +33,9 @@
         </v-snackbar>
       </v-col>
 
-      <!-- Right: quick summary card -->
+      <!-- Right: summary + media -->
       <v-col cols="12" md="4">
-        <v-card elevation="4">
+        <v-card elevation="4" class="mb-4">
           <v-card-title>Quick summary</v-card-title>
           <v-card-text>
             <p class="text-body-2 mb-2">
@@ -43,9 +43,7 @@
             </p>
             <p class="text-body-2 mb-2">
               Address:
-              <strong>
-                {{ editable.address || 'N/A' }}
-              </strong>
+              <strong>{{ editable.address || 'N/A' }}</strong>
               <span v-if="editable.suburb">
                 · {{ editable.suburb }}, {{ editable.state }} {{ editable.postcode }}
               </span>
@@ -69,87 +67,44 @@
                 </div>
               </div>
             </div>
-
-            <p class="text-body-2">In the full system, alerts sent to customers would include:</p>
-            <ul class="text-body-2 pl-4">
-              <li>Address and property type</li>
-              <li>Price guide (if set)</li>
-              <li>Main image</li>
-              <li>Optional link to floor plan</li>
-            </ul>
           </v-card-text>
         </v-card>
 
-        <!-- Gallery card -->
-        <v-card class="mt-4" elevation="4">
-          <v-card-title>Gallery</v-card-title>
+        <!-- Photos -->
+        <v-card elevation="4" class="mb-4">
+          <v-card-title>Photos</v-card-title>
           <v-card-text>
-            <div v-if="editable.gallery && editable.gallery.length" class="mb-4">
-              <v-carousel hide-delimiters height="220">
-                <v-carousel-item v-for="(url, index) in editable.gallery" :key="index">
-                  <v-img
-                    :src="url"
-                    cover
-                    height="220"
-                    class="cursor-pointer"
-                    @click="openImage(index)"
-                  />
-                </v-carousel-item>
-              </v-carousel>
-            </div>
-
-            <p v-else class="text-caption text-disabled mb-4">
-              No images or floor plans yet. Add some below.
-            </p>
-
-            <!-- Hidden native file input -->
-            <input
-              ref="fileInput"
-              type="file"
-              accept="image/*"
-              multiple
-              class="d-none"
-              @change="onFileChange"
+            <v-alert v-if="photoError" type="error" density="compact" class="mb-3">
+              {{ photoError }}
+            </v-alert>
+            <PhotoUploader
+              :items="original.photos"
+              :main-photo-path="original.mainPhoto"
+              kind="photo"
+              :disabled="photoUploading"
+              @add="(files) => handleAdd(files, 'photo')"
+              @remove="handleRemove"
+              @reorder="handleReorder"
+              @select="handleSelect"
             />
+          </v-card-text>
+        </v-card>
 
-            <v-btn
-              color="primary"
-              variant="outlined"
-              prepend-icon="mdi-image-plus"
-              @click="triggerFilePicker"
-            >
-              Add images from your computer
-            </v-btn>
+        <!-- Floorplans -->
+        <v-card elevation="4">
+          <v-card-title>Floor plans</v-card-title>
+          <v-card-text>
+            <PhotoUploader
+              :items="original.floorplans"
+              kind="floorplan"
+              @add="(files) => handleAdd(files, 'floorplan')"
+              @remove="handleRemove"
+              @reorder="handleReorder"
+            />
           </v-card-text>
         </v-card>
       </v-col>
     </v-row>
-    <!-- Image popup dialog -->
-    <v-dialog v-model="dialogOpen" max-width="900">
-      <v-card>
-        <v-card-title class="d-flex justify-space-between align-center">
-          <span>Image preview</span>
-          <v-btn icon="mdi-close" variant="text" @click="dialogOpen = false" />
-        </v-card-title>
-        <v-card-text>
-          <v-img
-            v-if="currentImageUrl"
-            :src="currentImageUrl"
-            max-height="600"
-            class="rounded mb-4"
-            cover
-          />
-          <div class="d-flex justify-space-between">
-            <v-btn variant="outlined" size="small" @click="prevImage" :disabled="!hasPrev">
-              Previous
-            </v-btn>
-            <v-btn variant="outlined" size="small" @click="nextImage" :disabled="!hasNext">
-              Next
-            </v-btn>
-          </div>
-        </v-card-text>
-      </v-card>
-    </v-dialog>
   </div>
 
   <div v-else>
@@ -159,13 +114,13 @@
   </div>
 </template>
 
-<!-- Scripting -->
 <script setup>
 import { ref, computed, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { usePropertyStore } from '../stores/propertyStore'
 import { createEmptyPropertyDraft } from '../constants/propertyDefaults'
 import PropertyForm from '../components/properties/PropertiesForm.vue'
+import PhotoUploader from '../components/base/PhotoUploader.vue'
 
 const route = useRoute()
 const router = useRouter()
@@ -174,29 +129,18 @@ const propertyStore = usePropertyStore()
 const id = route.params.id
 
 const original = computed(() => propertyStore.properties.find((p) => p.id === id))
-
 const propertyFound = computed(() => !!original.value)
 
-// local editable copy
 const editable = ref(createEmptyPropertyDraft())
-
 const snackbar = ref(false)
-const fileInput = ref(null)
-
-// dialog state for image popup
-const dialogOpen = ref(false)
-const selectedImageIndex = ref(0)
+const photoUploading = ref(false)
+const photoError = ref(null)
 
 watch(
   original,
   (value) => {
     if (value) {
-      const base = createEmptyPropertyDraft()
-      editable.value = {
-        ...base,
-        ...value,
-        gallery: value.gallery ? [...value.gallery] : [],
-      }
+      editable.value = { ...createEmptyPropertyDraft(), ...value }
     } else {
       editable.value = createEmptyPropertyDraft()
     }
@@ -211,25 +155,12 @@ const breadcrumbs = computed(() => [
 
 const createdAtFormatted = computed(() => {
   if (!editable.value.createdAt) return 'N/A'
-  const d = new Date(editable.value.createdAt)
-  return d.toLocaleDateString()
-})
-
-const currentImageUrl = computed(() => {
-  const gallery = editable.value.gallery || []
-  return gallery[selectedImageIndex.value] || null
-})
-
-const hasPrev = computed(() => selectedImageIndex.value > 0)
-const hasNext = computed(() => {
-  const gallery = editable.value.gallery || []
-  return selectedImageIndex.value < gallery.length - 1
+  return new Date(editable.value.createdAt).toLocaleDateString()
 })
 
 const keyStats = computed(() => {
   const landSizeLabel = editable.value.landSize || formatAreaDisplay(editable.value.landSizeSqm)
   const houseSizeLabel = editable.value.houseSize || formatAreaDisplay(editable.value.houseSizeSqm)
-
   return [
     { label: 'Bedrooms', icon: 'mdi-bed-outline', value: numberOrDash(editable.value.bedrooms) },
     { label: 'Bathrooms', icon: 'mdi-shower', value: numberOrDash(editable.value.bathrooms) },
@@ -241,87 +172,75 @@ const keyStats = computed(() => {
 
 function statusColor(status) {
   switch (status) {
-    case 'On Market':
-      return 'primary'
-    case 'Under Offer':
-      return 'amber-darken-2'
-    case 'Sold':
-      return 'grey-darken-1'
-    default:
-      return 'green-darken-1'
+    case 'On Market': return 'primary'
+    case 'Under Offer': return 'amber-darken-2'
+    case 'Sold': return 'grey-darken-1'
+    default: return 'green-darken-1'
   }
 }
 
 function saveChanges() {
   if (!propertyFound.value) return
-
   propertyStore.updateProperty(id, { ...editable.value })
   snackbar.value = true
+}
+
+function resetChanges() {
+  if (original.value) {
+    editable.value = { ...createEmptyPropertyDraft(), ...original.value }
+  }
 }
 
 function goBack() {
   router.push({ name: 'properties' })
 }
-function triggerFilePicker() {
-  if (fileInput.value) {
-    fileInput.value.click()
-  }
-}
 
-function onFileChange(event) {
-  const files = event.target.files
-  handleImageFiles(files)
-  // reset input so selecting the same file again still triggers change
-  event.target.value = ''
-}
-// Handle image uploads from the user's machine
-function handleImageFiles(files) {
-  if (!files || !files.length) return
+// ── photo event handlers ───────────────────────────────────────
 
-  const fileArray = Array.isArray(files) ? files : Array.from(files)
-
-  fileArray.forEach((file) => {
-    // For the demo: create a temporary object URL for preview
-    const objectUrl = URL.createObjectURL(file)
-
-    if (!editable.value.gallery) {
-      editable.value.gallery = []
+async function handleAdd(files, kind) {
+  photoError.value = null
+  photoUploading.value = true
+  try {
+    for (const file of files) {
+      await propertyStore.uploadPhoto(id, file, kind)
     }
-    editable.value.gallery.push(objectUrl)
-
-    // TODO (backend integration):
-    //  - Replace this with an API call like:
-    //      const url = await apiUploadPropertyImage(id, file);
-    //      editable.value.gallery.push(url);
-    //  - Revoke object URLs when component is destroyed:
-    //      URL.revokeObjectURL(objectUrl);
-  })
-}
-// Open dialog at a specific index
-function openImage(index) {
-  selectedImageIndex.value = index
-  dialogOpen.value = true
-}
-
-function prevImage() {
-  if (hasPrev.value) {
-    selectedImageIndex.value -= 1
+  } catch (e) {
+    photoError.value = `Upload failed: ${e.message}`
+  } finally {
+    photoUploading.value = false
   }
 }
 
-function nextImage() {
-  if (hasNext.value) {
-    selectedImageIndex.value += 1
+async function handleRemove(photoId) {
+  photoError.value = null
+  try {
+    await propertyStore.removePhoto(id, photoId)
+  } catch (e) {
+    photoError.value = `Delete failed: ${e.message}`
   }
 }
+
+async function handleReorder(orderedIds) {
+  try {
+    await propertyStore.reorderPhotos(id, orderedIds)
+  } catch (e) {
+    photoError.value = `Reorder failed: ${e.message}`
+  }
+}
+
+async function handleSelect(storagePath) {
+  try {
+    await propertyStore.setMainPhoto(id, storagePath)
+  } catch (e) {
+    photoError.value = `Failed to set main photo: ${e.message}`
+  }
+}
+
+// ── helpers ────────────────────────────────────────────────────
 
 function numberOrDash(value) {
-  if (value === 0) {
-    return '0'
-  }
-  if (value == null || value === '') {
-    return '—'
-  }
+  if (value === 0) return '0'
+  if (value == null || value === '') return '—'
   return `${value}`
 }
 
@@ -330,9 +249,7 @@ function textOrDash(value) {
 }
 
 function formatAreaDisplay(value) {
-  if (value == null || value === '') {
-    return ''
-  }
+  if (value == null || value === '') return ''
   return `${value} m²`
 }
 </script>
@@ -355,16 +272,11 @@ function formatAreaDisplay(value) {
   color: var(--bv-text-strong, #0f172a);
 }
 
-.status-pill {
-  display: flex;
-  align-items: center;
-}
-
 .stats-summary {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
   gap: 12px;
-  margin: 16px 0 24px;
+  margin: 16px 0 8px;
 }
 
 .stat-item {


### PR DESCRIPTION
- Add mediaService with upload, delete, signed URL cache, and reorder
- Add useSignedUrl composable with auto-refresh before expiry
- Add PhotoUploader base component (drag-drop upload, grid preview, drag-to-reorder, delete, set main photo)
- Extend propertiesService getProperty and updateProperty to join property_photos so photos persist through save actions
- Add uploadPhoto, removePhoto, reorderPhotos, setMainPhoto to propertyStore
- Rewrite PropertyDetailsView to use two PhotoUploader instances (photos + floorplans), remove old demo gallery code