### PR TITLE
Phase 3: customer feedback persistence + bidirectional property-custo…

### DIFF
--- a/Bold_Vision_CRM/src/components/customer/CustomerForm.vue
+++ b/Bold_Vision_CRM/src/components/customer/CustomerForm.vue
@@ -25,14 +25,6 @@
       />
     </v-col>
 
-    <v-col cols="12" md="4">
-      <v-text-field
-        v-model="form.interestedProperty"
-        label="Property of interest"
-        hint="e.g. 123 Smith St, or general area"
-      />
-    </v-col>
-
     <v-col cols="12">
       <v-textarea v-model="form.notes" label="Notes from call/SMS" rows="2" />
     </v-col>

--- a/Bold_Vision_CRM/src/components/customer/CustomerInterestsPanel.vue
+++ b/Bold_Vision_CRM/src/components/customer/CustomerInterestsPanel.vue
@@ -1,0 +1,332 @@
+<template>
+  <v-card elevation="4">
+    <v-card-title>Interested properties</v-card-title>
+
+    <v-card-text>
+      <div v-if="loading" class="text-center py-4">
+        <v-progress-circular indeterminate color="primary" size="24" />
+      </div>
+
+      <v-row v-else dense>
+        <v-col v-for="level in LEVELS" :key="level" cols="12" md="4">
+          <div
+            class="kanban-column"
+            :class="[`kanban-column--${level.toLowerCase()}`, { 'kanban-column--over': dragOverColumn === level }]"
+            @dragover.prevent="dragOverColumn = level"
+            @dragleave="onColumnLeave(level)"
+            @drop.prevent="onDrop(level)"
+          >
+            <header class="kanban-header">
+              <span class="kanban-title">
+                <span class="kanban-dot" :class="`kanban-dot--${level.toLowerCase()}`" />
+                {{ level }}
+                <span class="kanban-count">{{ countFor(level) }}</span>
+              </span>
+              <v-btn size="x-small" variant="text" icon="mdi-plus" @click="openAddDialog(level)" />
+            </header>
+
+            <div class="kanban-body">
+              <div
+                v-for="item in itemsFor(level)"
+                :key="item.id"
+                class="kanban-card"
+                :class="{ 'kanban-card--dragging': dragFrom?.propertyId === item.propertyId }"
+                draggable="true"
+                @dragstart="onDragStart(item)"
+                @dragend="onDragEnd"
+                @click="router.push({ name: 'property-details', params: { id: item.propertyId } })"
+              >
+                <div class="kanban-card-main">
+                  <p class="kanban-card-name">{{ item.propertyAddress }}</p>
+                  <p class="kanban-card-contact">{{ item.propertySuburb }} · {{ item.propertyType }}</p>
+                  <div class="kanban-card-chips">
+                    <v-chip :color="statusColor(item.propertyStatus)" size="x-small" variant="outlined">
+                      {{ item.propertyStatus }}
+                    </v-chip>
+                    <span v-if="item.propertyPriceGuide" class="kanban-card-price">
+                      {{ item.propertyPriceGuide }}
+                    </span>
+                  </div>
+                </div>
+                <v-btn
+                  icon="mdi-close"
+                  size="x-small"
+                  variant="text"
+                  color="grey"
+                  :loading="removing === item.id"
+                  @click.stop="remove(item)"
+                />
+              </div>
+
+              <p v-if="!itemsFor(level).length" class="kanban-empty">
+                No {{ level.toLowerCase() }} properties.
+              </p>
+            </div>
+          </div>
+        </v-col>
+      </v-row>
+    </v-card-text>
+
+    <!-- Add property dialog -->
+    <v-dialog v-model="dialog" max-width="420">
+      <v-card>
+        <v-card-title>Add {{ selectedLevel.toLowerCase() }} property</v-card-title>
+        <v-card-text>
+          <v-autocomplete
+            v-model="selectedProperty"
+            :items="availableProperties"
+            item-title="address"
+            item-value="id"
+            label="Property"
+            clearable
+            return-object
+          />
+          <v-select v-model="selectedLevel" :items="LEVELS" label="Interest level" />
+        </v-card-text>
+        <v-card-actions class="justify-end">
+          <v-btn variant="text" @click="closeDialog">Cancel</v-btn>
+          <v-btn
+            variant="outlined"
+            color="primary"
+            :disabled="!selectedProperty"
+            :loading="adding"
+            @click="addProperty"
+          >
+            Add
+          </v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+  </v-card>
+</template>
+
+<script setup>
+import { ref, computed, onMounted } from 'vue'
+import { useRouter } from 'vue-router'
+import { useCustomerStore } from '../../stores/customerStore'
+import { usePropertyStore } from '../../stores/propertyStore'
+
+const props = defineProps({ customerId: { type: String, required: true } })
+
+const router = useRouter()
+const customerStore = useCustomerStore()
+const propertyStore = usePropertyStore()
+
+const LEVELS = ['Hot', 'Warm', 'Cold']
+
+const loading = ref(false)
+const adding = ref(false)
+const removing = ref(null)
+
+const dialog = ref(false)
+const selectedProperty = ref(null)
+const selectedLevel = ref('Warm')
+
+const dragFrom = ref(null)
+const dragOverColumn = ref(null)
+
+const interests = computed(() => customerStore.propertyInterests[props.customerId] ?? [])
+
+const availableProperties = computed(() => {
+  const linked = new Set(interests.value.map((i) => i.propertyId))
+  return propertyStore.properties.filter((p) => !linked.has(p.id))
+})
+
+function itemsFor(level) {
+  return interests.value.filter((i) => i.interestLevel === level)
+}
+
+function countFor(level) {
+  return itemsFor(level).length
+}
+
+onMounted(async () => {
+  loading.value = true
+  try {
+    await customerStore.fetchPropertyInterests(props.customerId)
+    if (!propertyStore.loaded) await propertyStore.fetchProperties()
+  } finally {
+    loading.value = false
+  }
+})
+
+function openAddDialog(level) {
+  selectedLevel.value = level
+  dialog.value = true
+}
+
+async function addProperty() {
+  if (!selectedProperty.value) return
+  adding.value = true
+  try {
+    await customerStore.addPropertyInterest(props.customerId, selectedProperty.value.id, selectedLevel.value)
+    closeDialog()
+  } finally {
+    adding.value = false
+  }
+}
+
+function closeDialog() {
+  dialog.value = false
+  selectedProperty.value = null
+  selectedLevel.value = 'Warm'
+}
+
+function onDragStart(item) {
+  dragFrom.value = { propertyId: item.propertyId, fromLevel: item.interestLevel }
+}
+
+function onDragEnd() {
+  dragFrom.value = null
+  dragOverColumn.value = null
+}
+
+function onColumnLeave(level) {
+  if (dragOverColumn.value === level) dragOverColumn.value = null
+}
+
+async function onDrop(targetLevel) {
+  const moving = dragFrom.value
+  dragOverColumn.value = null
+  dragFrom.value = null
+  if (!moving || moving.fromLevel === targetLevel) return
+  await customerStore.addPropertyInterest(props.customerId, moving.propertyId, targetLevel)
+}
+
+async function remove(item) {
+  removing.value = item.id
+  try {
+    await customerStore.removePropertyInterest(props.customerId, item.propertyId)
+  } finally {
+    removing.value = null
+  }
+}
+
+function statusColor(status) {
+  if (status === 'On Market') return 'primary'
+  if (status === 'Under Offer') return 'amber-darken-2'
+  if (status === 'Sold') return 'grey-darken-1'
+  return 'green-darken-1'
+}
+</script>
+
+<style scoped>
+.kanban-column {
+  background: var(--bv-surface-muted, #f1f5f9);
+  border-radius: 12px;
+  padding: 10px;
+  min-height: 200px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  transition: outline 0.15s ease, background 0.15s ease;
+  outline: 2px solid transparent;
+}
+
+.kanban-column--over {
+  outline: 2px dashed #6366f1;
+  background: #eef2ff;
+}
+
+.kanban-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 4px 6px 0;
+}
+
+.kanban-title {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 600;
+  font-size: 0.9rem;
+  color: #0f172a;
+}
+
+.kanban-count {
+  font-weight: 500;
+  font-size: 0.8rem;
+  color: #64748b;
+}
+
+.kanban-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+}
+
+.kanban-dot--hot  { background: #ef4444; }
+.kanban-dot--warm { background: #f59e0b; }
+.kanban-dot--cold { background: #3b82f6; }
+
+.kanban-body {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.kanban-card {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  background: white;
+  border: 1px solid #e2e8f0;
+  border-radius: 10px;
+  padding: 10px 12px;
+  cursor: pointer;
+  transition: opacity 0.15s ease, box-shadow 0.15s ease;
+}
+
+.kanban-card:hover {
+  box-shadow: 0 2px 8px rgba(15, 23, 42, 0.08);
+}
+
+.kanban-card--dragging {
+  opacity: 0.5;
+  cursor: grabbing;
+}
+
+.kanban-card-main {
+  flex: 1;
+  min-width: 0;
+}
+
+.kanban-card-name {
+  margin: 0;
+  font-weight: 600;
+  font-size: 0.9rem;
+  color: #0f172a;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.kanban-card-contact {
+  margin: 2px 0 4px;
+  font-size: 0.8rem;
+  color: #475569;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.kanban-card-chips {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.kanban-card-price {
+  font-size: 0.75rem;
+  color: #64748b;
+}
+
+.kanban-empty {
+  margin: 6px;
+  font-size: 0.8rem;
+  color: #94a3b8;
+  font-style: italic;
+}
+</style>

--- a/Bold_Vision_CRM/src/components/properties/PropertyInterestsPanel.vue
+++ b/Bold_Vision_CRM/src/components/properties/PropertyInterestsPanel.vue
@@ -1,0 +1,326 @@
+<template>
+  <v-card elevation="4">
+    <v-card-title>Interested customers</v-card-title>
+
+    <v-card-text>
+      <div v-if="loading" class="text-center py-4">
+        <v-progress-circular indeterminate color="primary" size="24" />
+      </div>
+
+      <v-row v-else dense>
+        <v-col v-for="level in LEVELS" :key="level" cols="12" md="4">
+          <div
+            class="kanban-column"
+            :class="[`kanban-column--${level.toLowerCase()}`, { 'kanban-column--over': dragOverColumn === level }]"
+            @dragover.prevent="dragOverColumn = level"
+            @dragleave="onColumnLeave(level)"
+            @drop.prevent="onDrop(level)"
+          >
+            <header class="kanban-header">
+              <span class="kanban-title">
+                <span class="kanban-dot" :class="`kanban-dot--${level.toLowerCase()}`" />
+                {{ level }}
+                <span class="kanban-count">{{ countFor(level) }}</span>
+              </span>
+              <v-btn
+                size="x-small"
+                variant="text"
+                icon="mdi-plus"
+                @click="openAddDialog(level)"
+              />
+            </header>
+
+            <div class="kanban-body">
+              <div
+                v-for="item in itemsFor(level)"
+                :key="item.id"
+                class="kanban-card"
+                :class="{ 'kanban-card--dragging': dragFrom?.customerId === item.customerId }"
+                draggable="true"
+                @dragstart="onDragStart(item)"
+                @dragend="onDragEnd"
+                @click="router.push({ name: 'customer-details', params: { id: item.customerId } })"
+              >
+                <div class="kanban-card-main">
+                  <p class="kanban-card-name">{{ item.customerName }}</p>
+                  <p class="kanban-card-contact">{{ item.customerPhone || item.customerEmail || '—' }}</p>
+                  <p class="kanban-card-meta">Lead: {{ item.customerCategory }}</p>
+                </div>
+                <v-btn
+                  icon="mdi-close"
+                  size="x-small"
+                  variant="text"
+                  color="grey"
+                  :loading="removing === item.id"
+                  @click.stop="remove(item)"
+                />
+              </div>
+
+              <p v-if="!itemsFor(level).length" class="kanban-empty">
+                No {{ level.toLowerCase() }} customers.
+              </p>
+            </div>
+          </div>
+        </v-col>
+      </v-row>
+    </v-card-text>
+
+    <!-- Add customer dialog -->
+    <v-dialog v-model="dialog" max-width="420">
+      <v-card>
+        <v-card-title>Add {{ selectedLevel.toLowerCase() }} customer</v-card-title>
+        <v-card-text>
+          <v-autocomplete
+            v-model="selectedCustomer"
+            :items="availableCustomers"
+            item-title="name"
+            item-value="id"
+            label="Customer"
+            clearable
+            return-object
+          />
+          <v-select
+            v-model="selectedLevel"
+            :items="LEVELS"
+            label="Interest level"
+          />
+        </v-card-text>
+        <v-card-actions class="justify-end">
+          <v-btn variant="text" @click="closeDialog">Cancel</v-btn>
+          <v-btn
+            variant="outlined"
+            color="primary"
+            :disabled="!selectedCustomer"
+            :loading="adding"
+            @click="addCustomer"
+          >
+            Add
+          </v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+  </v-card>
+</template>
+
+<script setup>
+import { ref, computed, onMounted } from 'vue'
+import { useRouter } from 'vue-router'
+import { usePropertyStore } from '../../stores/propertyStore'
+import { useCustomerStore } from '../../stores/customerStore'
+
+const props = defineProps({ propertyId: { type: String, required: true } })
+
+const router = useRouter()
+const propertyStore = usePropertyStore()
+const customerStore = useCustomerStore()
+
+const LEVELS = ['Hot', 'Warm', 'Cold']
+
+const loading = ref(false)
+const adding = ref(false)
+const removing = ref(null)
+
+const dialog = ref(false)
+const selectedCustomer = ref(null)
+const selectedLevel = ref('Warm')
+
+const dragFrom = ref(null)
+const dragOverColumn = ref(null)
+
+const interests = computed(() => propertyStore.interests[props.propertyId] ?? [])
+
+const availableCustomers = computed(() => {
+  const linked = new Set(interests.value.map((i) => i.customerId))
+  return customerStore.customers.filter((c) => !linked.has(c.id))
+})
+
+function itemsFor(level) {
+  return interests.value.filter((i) => i.interestLevel === level)
+}
+
+function countFor(level) {
+  return itemsFor(level).length
+}
+
+onMounted(async () => {
+  loading.value = true
+  try {
+    await propertyStore.fetchInterests(props.propertyId)
+    if (!customerStore.loaded) await customerStore.fetchCustomers()
+  } finally {
+    loading.value = false
+  }
+})
+
+function openAddDialog(level) {
+  selectedLevel.value = level
+  dialog.value = true
+}
+
+async function addCustomer() {
+  if (!selectedCustomer.value) return
+  adding.value = true
+  try {
+    await propertyStore.addInterestedCustomer(props.propertyId, selectedCustomer.value.id, selectedLevel.value)
+    closeDialog()
+  } finally {
+    adding.value = false
+  }
+}
+
+function closeDialog() {
+  dialog.value = false
+  selectedCustomer.value = null
+  selectedLevel.value = 'Warm'
+}
+
+function onDragStart(item) {
+  dragFrom.value = { customerId: item.customerId, fromLevel: item.interestLevel }
+}
+
+function onDragEnd() {
+  dragFrom.value = null
+  dragOverColumn.value = null
+}
+
+function onColumnLeave(level) {
+  if (dragOverColumn.value === level) dragOverColumn.value = null
+}
+
+async function onDrop(targetLevel) {
+  const moving = dragFrom.value
+  dragOverColumn.value = null
+  dragFrom.value = null
+  if (!moving || moving.fromLevel === targetLevel) return
+  await propertyStore.updateInterestLevel(props.propertyId, moving.customerId, targetLevel)
+}
+
+async function remove(item) {
+  removing.value = item.id
+  try {
+    await propertyStore.removeInterestedCustomer(props.propertyId, item.customerId)
+  } finally {
+    removing.value = null
+  }
+}
+</script>
+
+<style scoped>
+.kanban-column {
+  background: var(--bv-surface-muted, #f1f5f9);
+  border-radius: 12px;
+  padding: 10px;
+  min-height: 220px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  transition: outline 0.15s ease, background 0.15s ease;
+  outline: 2px solid transparent;
+}
+
+.kanban-column--over {
+  outline: 2px dashed #6366f1;
+  background: #eef2ff;
+}
+
+.kanban-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 4px 6px 0;
+}
+
+.kanban-title {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 600;
+  font-size: 0.9rem;
+  color: #0f172a;
+}
+
+.kanban-count {
+  font-weight: 500;
+  font-size: 0.8rem;
+  color: #64748b;
+}
+
+.kanban-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+}
+
+.kanban-dot--hot { background: #ef4444; }
+.kanban-dot--warm { background: #f59e0b; }
+.kanban-dot--cold { background: #3b82f6; }
+
+.kanban-body {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.kanban-card {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  background: white;
+  border: 1px solid #e2e8f0;
+  border-radius: 10px;
+  padding: 10px 12px;
+  cursor: grab;
+  transition: opacity 0.15s ease, box-shadow 0.15s ease, transform 0.05s ease;
+}
+
+.kanban-card:active {
+  cursor: grabbing;
+}
+
+.kanban-card:hover {
+  box-shadow: 0 2px 8px rgba(15, 23, 42, 0.08);
+}
+
+.kanban-card--dragging {
+  opacity: 0.5;
+}
+
+.kanban-card-main {
+  flex: 1;
+  min-width: 0;
+}
+
+.kanban-card-name {
+  margin: 0;
+  font-weight: 600;
+  font-size: 0.9rem;
+  color: #0f172a;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.kanban-card-contact {
+  margin: 2px 0 0;
+  font-size: 0.8rem;
+  color: #475569;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.kanban-card-meta {
+  margin: 4px 0 0;
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: #94a3b8;
+}
+
+.kanban-empty {
+  margin: 6px;
+  font-size: 0.8rem;
+  color: #94a3b8;
+  font-style: italic;
+}
+</style>

--- a/Bold_Vision_CRM/src/services/customersService.js
+++ b/Bold_Vision_CRM/src/services/customersService.js
@@ -11,11 +11,9 @@ function mapRowToCustomer(row) {
     channel: row.channel ?? 'Call',
     category: row.category ?? 'Cold',
     notes: row.notes ?? '',
-    interestedProperty: '',
     createdAt: row.created_at,
     lastContactedAt: row.last_contacted_at ?? null,
     followUpCadence: CADENCE[row.category] ?? CADENCE.Cold,
-    feedback: [],
   }
 }
 
@@ -84,4 +82,24 @@ export async function setLastContacted(id, dateIso) {
     .update({ last_contacted_at: dateIso })
     .eq('id', id)
   if (error) throw error
+}
+
+export async function listFeedback(customerId) {
+  const { data, error } = await supabase
+    .from('customer_feedback')
+    .select('id, note, created_at')
+    .eq('customer_id', customerId)
+    .order('created_at', { ascending: false })
+  if (error) throw error
+  return data.map((row) => ({ id: row.id, note: row.note, date: row.created_at }))
+}
+
+export async function addFeedback(customerId, note) {
+  const { data, error } = await supabase
+    .from('customer_feedback')
+    .insert({ customer_id: customerId, note })
+    .select('id, note, created_at')
+    .single()
+  if (error) throw error
+  return { id: data.id, note: data.note, date: data.created_at }
 }

--- a/Bold_Vision_CRM/src/services/interestsService.js
+++ b/Bold_Vision_CRM/src/services/interestsService.js
@@ -1,0 +1,62 @@
+import { supabase } from './supabase'
+
+export async function listForProperty(propertyId) {
+  const { data, error } = await supabase
+    .from('property_interests')
+    .select('id, interest_level, updated_at, customer:customers(id, name, phone, email, category)')
+    .eq('property_id', propertyId)
+  if (error) throw error
+  return data.map((row) => ({
+    id: row.id,
+    interestLevel: row.interest_level,
+    updatedAt: row.updated_at,
+    customerId: row.customer.id,
+    customerName: row.customer.name,
+    customerPhone: row.customer.phone,
+    customerEmail: row.customer.email,
+    customerCategory: row.customer.category,
+  }))
+}
+
+export async function listForCustomer(customerId) {
+  const { data, error } = await supabase
+    .from('property_interests')
+    .select('id, interest_level, updated_at, property:properties(id, address, suburb, status, price_guide, type)')
+    .eq('customer_id', customerId)
+  if (error) throw error
+  return data.map((row) => ({
+    id: row.id,
+    interestLevel: row.interest_level,
+    updatedAt: row.updated_at,
+    propertyId: row.property.id,
+    propertyAddress: row.property.address,
+    propertySuburb: row.property.suburb,
+    propertyStatus: row.property.status,
+    propertyPriceGuide: row.property.price_guide,
+    propertyType: row.property.type,
+  }))
+}
+
+export async function upsertInterest(propertyId, customerId, interestLevel) {
+  const { error } = await supabase
+    .from('property_interests')
+    .upsert(
+      {
+        property_id: propertyId,
+        customer_id: customerId,
+        interest_level: interestLevel,
+        updated_at: new Date().toISOString(),
+      },
+      { onConflict: 'property_id,customer_id' },
+    )
+  if (error) throw error
+}
+
+export async function removeInterest(propertyId, customerId) {
+  const { error } = await supabase
+    .from('property_interests')
+    .delete()
+    .eq('property_id', propertyId)
+    .eq('customer_id', customerId)
+  if (error) throw error
+}

--- a/Bold_Vision_CRM/src/stores/customerStore.js
+++ b/Bold_Vision_CRM/src/stores/customerStore.js
@@ -5,13 +5,22 @@ import {
   updateCustomer,
   deleteCustomer,
   setLastContacted,
+  listFeedback,
+  addFeedback as addFeedbackService,
 } from '../services/customersService'
+import {
+  listForCustomer,
+  upsertInterest,
+  removeInterest,
+} from '../services/interestsService'
 
 const CADENCE = { Hot: 'Every 3 months', Warm: 'Every 6 months', Cold: 'Every 12 months' }
 
 export const useCustomerStore = defineStore('customers', {
   state: () => ({
     customers: [],
+    feedback: {},
+    propertyInterests: {},
     loading: false,
     error: null,
     loaded: false,
@@ -91,12 +100,30 @@ export const useCustomerStore = defineStore('customers', {
       }
     },
 
-    // Shimmed until Phase 3 wires real persistence
-    addFeedback(id, note, dateIso = new Date().toISOString()) {
-      const c = this.customers.find((c) => c.id === id)
-      if (!c) return
-      if (!c.feedback) c.feedback = []
-      c.feedback.unshift({ id: Date.now(), date: dateIso, note })
+    async fetchFeedback(customerId) {
+      const data = await listFeedback(customerId)
+      this.feedback[customerId] = data
+    },
+
+    async addFeedback(customerId, note) {
+      const entry = await addFeedbackService(customerId, note)
+      if (!this.feedback[customerId]) this.feedback[customerId] = []
+      this.feedback[customerId].unshift(entry)
+    },
+
+    async fetchPropertyInterests(customerId) {
+      const data = await listForCustomer(customerId)
+      this.propertyInterests[customerId] = data
+    },
+
+    async addPropertyInterest(customerId, propertyId, interestLevel = 'Warm') {
+      await upsertInterest(propertyId, customerId, interestLevel)
+      await this.fetchPropertyInterests(customerId)
+    },
+
+    async removePropertyInterest(customerId, propertyId) {
+      await removeInterest(propertyId, customerId)
+      await this.fetchPropertyInterests(customerId)
     },
   },
 })

--- a/Bold_Vision_CRM/src/stores/propertyStore.js
+++ b/Bold_Vision_CRM/src/stores/propertyStore.js
@@ -11,11 +11,17 @@ import {
   deletePropertyImage,
   reorderPhotos as reorderPhotoRows,
 } from '../services/mediaService'
-import { computeBadge } from '../utils/property'
+import {
+  listForProperty,
+  upsertInterest,
+  removeInterest,
+} from '../services/interestsService'
+import { computeBadge, sortByInterestLevel } from '../utils/property'
 
 export const usePropertyStore = defineStore('properties', {
   state: () => ({
     properties: [],
+    interests: {},
     loading: false,
     error: null,
     loaded: false,
@@ -118,6 +124,26 @@ export const usePropertyStore = defineStore('properties', {
 
     async setMainPhoto(propertyId, storagePath) {
       await this.updateProperty(propertyId, { mainPhoto: storagePath })
+    },
+
+    async fetchInterests(propertyId) {
+      const data = await listForProperty(propertyId)
+      this.interests[propertyId] = sortByInterestLevel(data)
+    },
+
+    async addInterestedCustomer(propertyId, customerId, interestLevel = 'Warm') {
+      await upsertInterest(propertyId, customerId, interestLevel)
+      await this.fetchInterests(propertyId)
+    },
+
+    async updateInterestLevel(propertyId, customerId, interestLevel) {
+      await upsertInterest(propertyId, customerId, interestLevel)
+      await this.fetchInterests(propertyId)
+    },
+
+    async removeInterestedCustomer(propertyId, customerId) {
+      await removeInterest(propertyId, customerId)
+      await this.fetchInterests(propertyId)
     },
   },
 })

--- a/Bold_Vision_CRM/src/views/CustomerDetailView.vue
+++ b/Bold_Vision_CRM/src/views/CustomerDetailView.vue
@@ -165,7 +165,7 @@
         </v-card>
 
         <!-- Quick summary card -->
-        <v-card elevation="2">
+        <v-card elevation="2" class="mb-4">
           <v-card-title>Quick summary</v-card-title>
           <v-card-text>
             <p class="text-body-2 mb-1">
@@ -185,31 +185,31 @@
               <strong>{{ lastContactedLabel }}</strong>
             </p>
 
-            <p class="text-body-2 mb-1">
+            <p class="text-body-2">
               Preferred channel:
               <strong>{{ editable.channel || 'N/A' }}</strong>
             </p>
-
-            <p class="text-body-2">
-              This summary will be used later to generate contact schedules and alerts for the team.
-            </p>
           </v-card-text>
         </v-card>
+
       </v-col>
     </v-row>
+
+    <!-- Interested properties (full-width) -->
+    <CustomerInterestsPanel :customer-id="id" class="mt-2" />
   </v-container>
 </template>
 
 <script setup>
-import { ref, computed } from 'vue'
+import { ref, computed, onMounted } from 'vue'
 import { useRoute } from 'vue-router'
 import { useCustomerStore } from '../stores/customerStore'
+import CustomerInterestsPanel from '../components/customer/CustomerInterestsPanel.vue'
 
-// routing + store
 const route = useRoute()
 const store = useCustomerStore()
 
-const id = Number(route.params.id)
+const id = route.params.id
 
 // locate customer from store
 const original = computed(() => store.customers.find((c) => c.id === id))
@@ -275,15 +275,18 @@ const lastContactedLabel = computed(() =>
   editable.value.lastContactedAt ? formatDate(editable.value.lastContactedAt) : 'Not set',
 )
 
-// feedback entries from the Customer store
-const feedbackEntries = computed(() => original.value?.feedback || [])
+const feedbackEntries = computed(() => store.feedback[id] ?? [])
 
 const newFeedback = ref('')
 
-function addFeedback() {
+onMounted(() => {
+  store.fetchFeedback(id)
+})
+
+async function addFeedback() {
   const note = newFeedback.value.trim()
   if (!note || !customerFound.value) return
-  store.addFeedback(id, note)
+  await store.addFeedback(id, note)
   newFeedback.value = ''
 }
 

--- a/Bold_Vision_CRM/src/views/CustomersView.vue
+++ b/Bold_Vision_CRM/src/views/CustomersView.vue
@@ -172,7 +172,6 @@ const newCustomer = ref({
   email: '',
   channel: 'Call',
   category: 'Cold',
-  interestedProperty: '',
   notes: '',
 })
 
@@ -188,7 +187,6 @@ function resetNewCustomer() {
     email: '',
     channel: 'Call',
     category: 'Cold',
-    interestedProperty: '',
     notes: '',
   }
 }

--- a/Bold_Vision_CRM/src/views/PropertyDetailsView.vue
+++ b/Bold_Vision_CRM/src/views/PropertyDetailsView.vue
@@ -105,6 +105,9 @@
         </v-card>
       </v-col>
     </v-row>
+
+    <!-- Interested customers (full-width Kanban) -->
+    <PropertyInterestsPanel :property-id="id" class="mt-2" />
   </div>
 
   <div v-else>
@@ -121,6 +124,7 @@ import { usePropertyStore } from '../stores/propertyStore'
 import { createEmptyPropertyDraft } from '../constants/propertyDefaults'
 import PropertyForm from '../components/properties/PropertiesForm.vue'
 import PhotoUploader from '../components/base/PhotoUploader.vue'
+import PropertyInterestsPanel from '../components/properties/PropertyInterestsPanel.vue'
 
 const route = useRoute()
 const router = useRouter()

--- a/supabase/migrations/0002_customer_feedback_and_interests.sql
+++ b/supabase/migrations/0002_customer_feedback_and_interests.sql
@@ -1,0 +1,65 @@
+-- ─────────────────────────────────────────────────────────────────────────────
+-- Phase 3: customer_feedback + property_interests
+-- ─────────────────────────────────────────────────────────────────────────────
+
+-- ── customer_feedback ────────────────────────────────────────────────────────
+create table public.customer_feedback (
+  id          uuid        primary key default gen_random_uuid(),
+  auth_user_id uuid       not null,
+  customer_id uuid        not null references public.customers(id) on delete cascade,
+  note        text        not null,
+  created_at  timestamptz not null default now()
+);
+
+create or replace function public.set_customer_feedback_auth_user_id()
+returns trigger language plpgsql security definer as $$
+begin
+  new.auth_user_id = auth.uid();
+  return new;
+end;
+$$;
+
+create trigger set_customer_feedback_auth_user_id
+  before insert on public.customer_feedback
+  for each row execute procedure public.set_customer_feedback_auth_user_id();
+
+alter table public.customer_feedback enable row level security;
+
+create policy "agent owns feedback"
+  on public.customer_feedback
+  using  (auth.uid() = auth_user_id)
+  with check (auth.uid() = auth_user_id);
+
+-- ── property_interests ───────────────────────────────────────────────────────
+create table public.property_interests (
+  id            uuid        primary key default gen_random_uuid(),
+  auth_user_id  uuid        not null,
+  property_id   uuid        not null references public.properties(id) on delete cascade,
+  customer_id   uuid        not null references public.customers(id) on delete cascade,
+  interest_level text       not null check (interest_level in ('Hot', 'Warm', 'Cold')),
+  updated_at    timestamptz not null default now(),
+  unique (property_id, customer_id)
+);
+
+create or replace function public.set_property_interests_auth_user_id()
+returns trigger language plpgsql security definer as $$
+begin
+  new.auth_user_id = auth.uid();
+  return new;
+end;
+$$;
+
+create trigger set_property_interests_auth_user_id
+  before insert on public.property_interests
+  for each row execute procedure public.set_property_interests_auth_user_id();
+
+alter table public.property_interests enable row level security;
+
+create policy "agent owns interests"
+  on public.property_interests
+  using  (auth.uid() = auth_user_id)
+  with check (auth.uid() = auth_user_id);
+
+-- ── grants ───────────────────────────────────────────────────────────────────
+grant select, insert, update, delete on public.customer_feedback   to authenticated;
+grant select, insert, update, delete on public.property_interests  to authenticated;


### PR DESCRIPTION
…mer interest Kanban

- Add customer_feedback and property_interests tables with RLS, triggers, and GRANTs (migration 0002)
- Add interestsService with listForProperty, listForCustomer, upsertInterest, removeInterest
- Add listFeedback and addFeedback to customersService; remove dead interestedProperty field
- Update propertyStore and customerStore with interest and feedback actions
- Replace flat interest list with 3-column Kanban (Hot/Warm/Cold) on both PropertyDetailsView and CustomerDetailView; cards draggable between columns, per-column Add button, click-through navigation
- Fix UUID route param bug in CustomerDetailView (Number() cast → string)
- Wire feedback section in CustomerDetailView to real Supabase persistence