### PR TITLE
Phase 4: follow-ups dashboard and Home view rewrite

### DIFF
--- a/Bold_Vision_CRM/src/App.vue
+++ b/Bold_Vision_CRM/src/App.vue
@@ -53,6 +53,12 @@
               title="Properties"
               rounded="lg"
             />
+            <v-list-item
+              :to="{ name: 'follow-ups' }"
+              prepend-icon="mdi-bell-ring-outline"
+              title="Follow-ups"
+              rounded="lg"
+            />
           </v-list>
 
           <v-divider class="my-4" />

--- a/Bold_Vision_CRM/src/composables/useCustomerFollowups.js
+++ b/Bold_Vision_CRM/src/composables/useCustomerFollowups.js
@@ -1,0 +1,33 @@
+import { computed } from 'vue'
+import { daysOverdue, needsAttention, isOverdue } from '../utils/followUp'
+
+export function useCustomerFollowups(customers) {
+  function groupForCategory(category) {
+    return computed(() =>
+      customers.value
+        .filter((c) => c.category === category && needsAttention(c))
+        .sort((a, b) => {
+          const da = daysOverdue(a)
+          const db = daysOverdue(b)
+          if (da === Infinity) return -1
+          if (db === Infinity) return 1
+          return db - da
+        }),
+    )
+  }
+
+  const hot = groupForCategory('Hot')
+  const warm = groupForCategory('Warm')
+  const cold = groupForCategory('Cold')
+
+  const overdueCount = computed(
+    () =>
+      [...hot.value, ...warm.value, ...cold.value].filter((c) => isOverdue(c)).length,
+  )
+
+  const hotOverdueCount = computed(() => hot.value.filter((c) => isOverdue(c)).length)
+  const warmOverdueCount = computed(() => warm.value.filter((c) => isOverdue(c)).length)
+  const coldOverdueCount = computed(() => cold.value.filter((c) => isOverdue(c)).length)
+
+  return { hot, warm, cold, overdueCount, hotOverdueCount, warmOverdueCount, coldOverdueCount }
+}

--- a/Bold_Vision_CRM/src/router/index.js
+++ b/Bold_Vision_CRM/src/router/index.js
@@ -4,6 +4,7 @@ import CustomersView from '../views/CustomersView.vue'
 import CustomerDetailView from '../views/CustomerDetailView.vue'
 import PropertiesView from '../views/PropertiesView.vue'
 import PropertyDetailsView from '../views/PropertyDetailsView.vue'
+import FollowUpsView from '../views/FollowUpsView.vue'
 import LoginView from '../views/LoginView.vue'
 import { getSession } from '../services/authService'
 
@@ -43,6 +44,12 @@ const router = createRouter({
       path: '/customers/:id',
       name: 'customer-details',
       component: CustomerDetailView,
+      meta: { requiresAuth: true },
+    },
+    {
+      path: '/follow-ups',
+      name: 'follow-ups',
+      component: FollowUpsView,
       meta: { requiresAuth: true },
     },
   ],

--- a/Bold_Vision_CRM/src/utils/followUp.js
+++ b/Bold_Vision_CRM/src/utils/followUp.js
@@ -1,0 +1,31 @@
+const CADENCE_MONTHS = { Hot: 3, Warm: 6, Cold: 12 }
+
+export function cadenceMonths(category) {
+  return CADENCE_MONTHS[category] ?? 12
+}
+
+export function cadenceLabel(category) {
+  const months = cadenceMonths(category)
+  return `Every ${months} months (${category})`
+}
+
+// Positive = days past due. Infinity = never contacted. Negative = days until due.
+export function daysOverdue(customer, today = new Date()) {
+  if (!customer.lastContactedAt) return Infinity
+  const lastContacted = new Date(customer.lastContactedAt)
+  const dueDate = new Date(lastContacted)
+  dueDate.setMonth(dueDate.getMonth() + cadenceMonths(customer.category))
+  const diffMs = today - dueDate
+  return Math.floor(diffMs / (1000 * 60 * 60 * 24))
+}
+
+export function isOverdue(customer, today = new Date()) {
+  const days = daysOverdue(customer, today)
+  return days === Infinity || days >= 0
+}
+
+// Needs attention: overdue OR within 30 days of due date
+export function needsAttention(customer, today = new Date()) {
+  const days = daysOverdue(customer, today)
+  return days === Infinity || days >= -30
+}

--- a/Bold_Vision_CRM/src/views/FollowUpsView.vue
+++ b/Bold_Vision_CRM/src/views/FollowUpsView.vue
@@ -1,0 +1,191 @@
+<template>
+  <div class="followups">
+    <div class="followups-header mb-6">
+      <h2>Follow-ups</h2>
+      <p class="text-body-2 text-medium-emphasis mt-1">
+        {{ overdueCount }} customer{{ overdueCount === 1 ? '' : 's' }} overdue for contact
+      </p>
+    </div>
+
+    <v-tabs v-model="activeTab" color="primary" class="mb-4">
+      <v-tab value="Hot">
+        <v-icon start>mdi-fire</v-icon>
+        Hot
+        <v-badge v-if="hot.length" :content="hot.length" color="red" inline class="ml-2" />
+      </v-tab>
+      <v-tab value="Warm">
+        <v-icon start>mdi-weather-sunny</v-icon>
+        Warm
+        <v-badge v-if="warm.length" :content="warm.length" color="orange" inline class="ml-2" />
+      </v-tab>
+      <v-tab value="Cold">
+        <v-icon start>mdi-snowflake</v-icon>
+        Cold
+        <v-badge v-if="cold.length" :content="cold.length" color="blue" inline class="ml-2" />
+      </v-tab>
+    </v-tabs>
+
+    <v-window v-model="activeTab">
+      <v-window-item v-for="(group, level) in { Hot: hot, Warm: warm, Cold: cold }" :key="level" :value="level">
+        <div v-if="group.length" class="followup-list">
+          <div
+            v-for="customer in group"
+            :key="customer.id"
+            class="followup-card"
+          >
+            <div class="followup-card__info">
+              <p class="followup-card__name">{{ customer.name }}</p>
+              <p class="followup-card__sub">{{ customer.phone || customer.email || 'No contact info' }}</p>
+            </div>
+
+            <div class="followup-card__status">
+              <v-chip
+                :color="overdueChipColor(customer)"
+                size="small"
+                variant="tonal"
+              >
+                {{ overdueLabel(customer) }}
+              </v-chip>
+            </div>
+
+            <div class="followup-card__actions">
+              <v-btn
+                size="small"
+                variant="outlined"
+                color="primary"
+                class="mr-2"
+                @click="markContacted(customer)"
+              >
+                Mark contacted
+              </v-btn>
+              <v-btn
+                size="small"
+                variant="tonal"
+                color="primary"
+                :to="`/customers/${customer.id}`"
+              >
+                View
+              </v-btn>
+            </div>
+          </div>
+        </div>
+
+        <div v-else class="empty-state">
+          <v-icon size="48" color="success" class="mb-3">mdi-check-circle-outline</v-icon>
+          <p class="text-body-1 font-weight-medium">All {{ level }} customers are up to date.</p>
+          <p class="text-body-2 text-medium-emphasis">No follow-ups needed right now.</p>
+        </div>
+      </v-window-item>
+    </v-window>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed } from 'vue'
+import { useCustomerStore } from '../stores/customerStore'
+import { useCustomerFollowups } from '../composables/useCustomerFollowups'
+import { daysOverdue, isOverdue } from '../utils/followUp'
+
+const store = useCustomerStore()
+const customers = computed(() => store.customers)
+
+const activeTab = ref('Hot')
+
+const { hot, warm, cold, overdueCount } = useCustomerFollowups(customers)
+
+function overdueLabel(customer) {
+  const days = daysOverdue(customer)
+  if (days === Infinity) return 'Never contacted'
+  if (days >= 0) return `${days} day${days === 1 ? '' : 's'} overdue`
+  return `Due in ${Math.abs(days)} day${Math.abs(days) === 1 ? '' : 's'}`
+}
+
+function overdueChipColor(customer) {
+  const days = daysOverdue(customer)
+  if (isOverdue(customer) || days === Infinity) return 'error'
+  return 'warning'
+}
+
+async function markContacted(customer) {
+  await store.setLastContacted(customer.id, new Date().toISOString())
+}
+</script>
+
+<style scoped>
+.followups-header h2 {
+  font-size: 1.6rem;
+  font-weight: 700;
+}
+
+.followup-list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.followup-card {
+  display: grid;
+  grid-template-columns: 1fr auto auto;
+  align-items: center;
+  gap: 16px;
+  padding: 14px 20px;
+  background: white;
+  border-radius: 12px;
+  border: 1px solid #e2e8f0;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06);
+}
+
+.followup-card__name {
+  font-weight: 600;
+  font-size: 0.95rem;
+  margin: 0 0 2px;
+}
+
+.followup-card__sub {
+  font-size: 0.82rem;
+  color: #64748b;
+  margin: 0;
+}
+
+.followup-card__status {
+  white-space: nowrap;
+}
+
+.followup-card__actions {
+  display: flex;
+  align-items: center;
+  white-space: nowrap;
+}
+
+.empty-state {
+  padding: 64px 24px;
+  text-align: center;
+  color: #475569;
+}
+
+@media (max-width: 640px) {
+  .followup-card {
+    grid-template-columns: 1fr auto;
+    grid-template-rows: auto auto;
+  }
+
+  .followup-card__status {
+    grid-column: 2;
+    grid-row: 1;
+  }
+
+  .followup-card__info {
+    grid-column: 1;
+    grid-row: 1;
+  }
+
+  .followup-card__actions {
+    grid-column: 1 / -1;
+    grid-row: 2;
+  }
+
+  .followup-card__actions .v-btn {
+    flex: 1;
+  }
+}
+</style>

--- a/Bold_Vision_CRM/src/views/HomeView.vue
+++ b/Bold_Vision_CRM/src/views/HomeView.vue
@@ -1,5 +1,159 @@
 <template>
-  <main>
-    <h1>Home</h1>
-  </main>
+  <div class="home">
+    <div class="home-header mb-6">
+      <h2>Dashboard</h2>
+      <p class="text-body-2 text-medium-emphasis mt-1">
+        {{ today }}
+      </p>
+    </div>
+
+    <!-- Follow-up summary -->
+    <v-card elevation="4" class="mb-6">
+      <v-card-title class="d-flex align-center">
+        <v-icon class="mr-2" color="primary">mdi-bell-ring-outline</v-icon>
+        Follow-ups needed
+      </v-card-title>
+
+      <v-card-text>
+        <div v-if="overdueCount > 0">
+          <p class="text-body-1 mb-4">
+            <strong>{{ overdueCount }}</strong> customer{{ overdueCount === 1 ? '' : 's' }}
+            {{ overdueCount === 1 ? 'is' : 'are' }} overdue for contact.
+          </p>
+
+          <div class="category-summary">
+            <div
+              v-for="item in categorySummary"
+              :key="item.label"
+              class="category-summary__item"
+              :class="`category-summary__item--${item.label.toLowerCase()}`"
+            >
+              <p class="category-summary__count">{{ item.count }}</p>
+              <p class="category-summary__label">{{ item.label }}</p>
+            </div>
+          </div>
+        </div>
+
+        <div v-else class="all-clear">
+          <v-icon size="40" color="success" class="mb-2">mdi-check-circle-outline</v-icon>
+          <p class="text-body-1 font-weight-medium">All caught up!</p>
+          <p class="text-body-2 text-medium-emphasis">No customers are overdue for contact.</p>
+        </div>
+      </v-card-text>
+
+      <v-card-actions class="px-4 pb-4">
+        <v-spacer />
+        <v-btn
+          color="primary"
+          variant="outlined"
+          :to="{ name: 'follow-ups' }"
+          append-icon="mdi-arrow-right"
+        >
+          View follow-ups
+        </v-btn>
+      </v-card-actions>
+    </v-card>
+
+    <!-- Approaching (not yet overdue) -->
+    <v-card v-if="approachingCount > 0" elevation="2" variant="tonal" color="warning">
+      <v-card-text class="d-flex align-center">
+        <v-icon class="mr-3" color="warning">mdi-clock-outline</v-icon>
+        <span class="text-body-2">
+          <strong>{{ approachingCount }}</strong> more customer{{ approachingCount === 1 ? '' : 's' }}
+          approaching their due date in the next 30 days.
+        </span>
+        <v-spacer />
+        <v-btn size="small" variant="text" :to="{ name: 'follow-ups' }">View</v-btn>
+      </v-card-text>
+    </v-card>
+  </div>
 </template>
+
+<script setup>
+import { computed } from 'vue'
+import { useCustomerStore } from '../stores/customerStore'
+import { useCustomerFollowups } from '../composables/useCustomerFollowups'
+import { isOverdue } from '../utils/followUp'
+
+const store = useCustomerStore()
+const customers = computed(() => store.customers)
+
+const { hot, warm, cold, overdueCount, hotOverdueCount, warmOverdueCount, coldOverdueCount } =
+  useCustomerFollowups(customers)
+
+const today = new Date().toLocaleDateString('en-AU', {
+  weekday: 'long',
+  year: 'numeric',
+  month: 'long',
+  day: 'numeric',
+})
+
+const categorySummary = computed(() => [
+  { label: 'Hot', count: hotOverdueCount.value },
+  { label: 'Warm', count: warmOverdueCount.value },
+  { label: 'Cold', count: coldOverdueCount.value },
+].filter((item) => item.count > 0))
+
+const approachingCount = computed(() =>
+  [...hot.value, ...warm.value, ...cold.value].filter((c) => !isOverdue(c)).length,
+)
+</script>
+
+<style scoped>
+.home-header h2 {
+  font-size: 1.6rem;
+  font-weight: 700;
+}
+
+.category-summary {
+  display: flex;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.category-summary__item {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 16px 24px;
+  border-radius: 12px;
+  min-width: 90px;
+  background: #f1f5f9;
+}
+
+.category-summary__item--hot {
+  background: #fee2e2;
+  color: #991b1b;
+}
+
+.category-summary__item--warm {
+  background: #ffedd5;
+  color: #9a3412;
+}
+
+.category-summary__item--cold {
+  background: #dbeafe;
+  color: #1e3a8a;
+}
+
+.category-summary__count {
+  font-size: 2rem;
+  font-weight: 700;
+  margin: 0;
+  line-height: 1;
+}
+
+.category-summary__label {
+  font-size: 0.8rem;
+  font-weight: 600;
+  margin: 4px 0 0;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.all-clear {
+  padding: 16px 0;
+  text-align: center;
+}
+</style>


### PR DESCRIPTION
- src/utils/followUp.js: cadenceMonths, daysOverdue, isOverdue, needsAttention helpers
- src/composables/useCustomerFollowups.js: reactive grouping by category (overdue + approaching 30d)
- src/views/FollowUpsView.vue: 3-tab Kanban (Hot/Warm/Cold) with Mark Contacted + View actions
- src/views/HomeView.vue: dashboard showing overdue counts by category with CTA to /follow-ups
- router + drawer: /follow-ups route and nav entry