### PR TITLE
Phase 5: Follow-up Kanban, next_contact_at scheduling, CustomerDetail…

### DIFF
--- a/Bold_Vision_CRM/src/components/followups/KanbanCard.vue
+++ b/Bold_Vision_CRM/src/components/followups/KanbanCard.vue
@@ -1,0 +1,165 @@
+<template>
+  <div
+    class="kanban-card"
+    :class="[`kanban-card--${customer.category?.toLowerCase()}`, { 'kanban-card--dragging': isDragging }]"
+    draggable="true"
+    @dragstart="onDragStart"
+    @dragend="onDragEnd"
+  >
+    <div class="kanban-card__body" @click="$router.push(`/customers/${customer.id}`)">
+      <div class="kanban-card__top-row">
+        <p class="kanban-card__name">{{ customer.name }}</p>
+        <span class="kanban-card__category-dot" :class="`dot--${customer.category?.toLowerCase()}`" :title="customer.category" />
+      </div>
+      <p class="kanban-card__sub">{{ customer.phone || customer.email || 'No contact info' }}</p>
+      <div class="kanban-card__footer">
+        <span v-if="timeLabel" class="kanban-card__time">
+          <v-icon size="10" class="mr-1">mdi-clock-outline</v-icon>{{ timeLabel }}
+        </span>
+        <v-chip v-if="statusChip" :color="statusChip.color" size="x-small" variant="tonal" class="kanban-card__chip">
+          {{ statusChip.label }}
+        </v-chip>
+      </div>
+    </div>
+
+    <div class="kanban-card__actions">
+      <v-menu location="bottom end">
+        <template #activator="{ props }">
+          <v-btn v-bind="props" icon="mdi-dots-vertical" size="x-small" variant="text" density="compact" />
+        </template>
+        <v-list density="compact">
+          <v-list-item prepend-icon="mdi-check-circle-outline" title="Mark contacted" @click="$emit('mark-contacted')" />
+          <v-list-item prepend-icon="mdi-calendar-remove-outline" title="Clear schedule" @click="$emit('clear-schedule')" />
+          <v-list-item prepend-icon="mdi-account-details-outline" title="View customer" :to="`/customers/${customer.id}`" />
+        </v-list>
+      </v-menu>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { computed, ref } from 'vue'
+
+const props = defineProps({
+  customer: { type: Object, required: true },
+  showStatus: { type: Boolean, default: false },
+})
+
+const emit = defineEmits(['dragstart', 'dragend', 'mark-contacted', 'clear-schedule'])
+
+const isDragging = ref(false)
+
+const timeLabel = computed(() => {
+  if (!props.customer.nextContactAt) return null
+  const d = new Date(props.customer.nextContactAt)
+  return d.toLocaleTimeString('en-AU', { hour: '2-digit', minute: '2-digit', hour12: true })
+})
+
+const statusChip = computed(() => {
+  if (!props.showStatus) return null
+  if (!props.customer.nextContactAt && !props.customer.lastContactedAt) {
+    return { label: 'Never contacted', color: 'error' }
+  }
+  if (!props.customer.nextContactAt) {
+    return { label: 'No schedule', color: 'warning' }
+  }
+  return null
+})
+
+function onDragStart(e) {
+  isDragging.value = true
+  e.dataTransfer.effectAllowed = 'move'
+  emit('dragstart', props.customer)
+}
+
+function onDragEnd() {
+  isDragging.value = false
+  emit('dragend')
+}
+</script>
+
+<style scoped>
+.kanban-card {
+  display: flex;
+  align-items: flex-start;
+  gap: 4px;
+  padding: 10px 8px 10px 12px;
+  background: white;
+  border-radius: 8px;
+  border: 1px solid #e2e8f0;
+  border-left-width: 4px;
+  cursor: grab;
+  transition: box-shadow 0.15s, opacity 0.15s;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.06);
+}
+.kanban-card:hover { box-shadow: 0 4px 10px rgba(0,0,0,0.1); }
+.kanban-card--dragging { opacity: 0.35; cursor: grabbing; }
+
+.kanban-card--hot  { border-left-color: #ef4444; }
+.kanban-card--warm { border-left-color: #f97316; }
+.kanban-card--cold { border-left-color: #3b82f6; }
+
+.kanban-card__body { flex: 1; min-width: 0; cursor: pointer; }
+
+.kanban-card__top-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 2px;
+}
+
+.kanban-card__name {
+  font-weight: 600;
+  font-size: 0.85rem;
+  margin: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  flex: 1;
+  min-width: 0;
+}
+
+.kanban-card__category-dot {
+  flex-shrink: 0;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+}
+.dot--hot  { background: #ef4444; }
+.dot--warm { background: #f97316; }
+.dot--cold { background: #3b82f6; }
+
+.kanban-card__sub {
+  font-size: 0.75rem;
+  color: #64748b;
+  margin: 0 0 4px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.kanban-card__footer {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.kanban-card__time {
+  font-size: 0.7rem;
+  color: #94a3b8;
+  font-weight: 500;
+  display: flex;
+  align-items: center;
+}
+
+.kanban-card__chip { font-size: 0.65rem !important; }
+
+.kanban-card__actions {
+  flex-shrink: 0;
+  margin-top: -4px;
+  opacity: 0;
+  transition: opacity 0.15s;
+}
+.kanban-card:hover .kanban-card__actions { opacity: 1; }
+</style>

--- a/Bold_Vision_CRM/src/composables/useCustomerFollowups.js
+++ b/Bold_Vision_CRM/src/composables/useCustomerFollowups.js
@@ -1,33 +1,27 @@
 import { computed } from 'vue'
-import { daysOverdue, needsAttention, isOverdue } from '../utils/followUp'
+import { bucketCustomersForWeek } from '../utils/followUp'
 
 export function useCustomerFollowups(customers) {
-  function groupForCategory(category) {
-    return computed(() =>
-      customers.value
-        .filter((c) => c.category === category && needsAttention(c))
-        .sort((a, b) => {
-          const da = daysOverdue(a)
-          const db = daysOverdue(b)
-          if (da === Infinity) return -1
-          if (db === Infinity) return 1
-          return db - da
-        }),
-    )
-  }
+  const buckets = computed(() => bucketCustomersForWeek(customers.value))
 
-  const hot = groupForCategory('Hot')
-  const warm = groupForCategory('Warm')
-  const cold = groupForCategory('Cold')
+  const overdue = computed(() => buckets.value.overdue)
+  const unscheduled = computed(() => buckets.value.unscheduled)
+  const days = computed(() => buckets.value.days)
 
-  const overdueCount = computed(
-    () =>
-      [...hot.value, ...warm.value, ...cold.value].filter((c) => isOverdue(c)).length,
+  const overdueCount = computed(() => overdue.value.length)
+  const unscheduledCount = computed(() => unscheduled.value.length)
+
+  // Total needing attention this week (overdue + unscheduled + today's column)
+  const needsAttentionCount = computed(
+    () => overdue.value.length + unscheduled.value.length,
   )
 
-  const hotOverdueCount = computed(() => hot.value.filter((c) => isOverdue(c)).length)
-  const warmOverdueCount = computed(() => warm.value.filter((c) => isOverdue(c)).length)
-  const coldOverdueCount = computed(() => cold.value.filter((c) => isOverdue(c)).length)
-
-  return { hot, warm, cold, overdueCount, hotOverdueCount, warmOverdueCount, coldOverdueCount }
+  return {
+    overdue,
+    unscheduled,
+    days,
+    overdueCount,
+    unscheduledCount,
+    needsAttentionCount,
+  }
 }

--- a/Bold_Vision_CRM/src/services/customersService.js
+++ b/Bold_Vision_CRM/src/services/customersService.js
@@ -1,7 +1,5 @@
 import { supabase } from './supabase'
 
-const CADENCE = { Hot: 'Every 3 months', Warm: 'Every 6 months', Cold: 'Every 12 months' }
-
 function mapRowToCustomer(row) {
   return {
     id: row.id,
@@ -13,7 +11,7 @@ function mapRowToCustomer(row) {
     notes: row.notes ?? '',
     createdAt: row.created_at,
     lastContactedAt: row.last_contacted_at ?? null,
-    followUpCadence: CADENCE[row.category] ?? CADENCE.Cold,
+    nextContactAt: row.next_contact_at ?? null,
   }
 }
 
@@ -80,6 +78,14 @@ export async function setLastContacted(id, dateIso) {
   const { error } = await supabase
     .from('customers')
     .update({ last_contacted_at: dateIso })
+    .eq('id', id)
+  if (error) throw error
+}
+
+export async function setNextContactAt(id, dateIso) {
+  const { error } = await supabase
+    .from('customers')
+    .update({ next_contact_at: dateIso })
     .eq('id', id)
   if (error) throw error
 }

--- a/Bold_Vision_CRM/src/stores/customerStore.js
+++ b/Bold_Vision_CRM/src/stores/customerStore.js
@@ -5,6 +5,7 @@ import {
   updateCustomer,
   deleteCustomer,
   setLastContacted,
+  setNextContactAt as setNextContactAtService,
   listFeedback,
   addFeedback as addFeedbackService,
 } from '../services/customersService'
@@ -14,7 +15,6 @@ import {
   removeInterest,
 } from '../services/interestsService'
 
-const CADENCE = { Hot: 'Every 3 months', Warm: 'Every 6 months', Cold: 'Every 12 months' }
 
 export const useCustomerStore = defineStore('customers', {
   state: () => ({
@@ -58,12 +58,7 @@ export const useCustomerStore = defineStore('customers', {
       const previous = index !== -1 ? { ...this.customers[index] } : null
 
       if (index !== -1) {
-        this.customers[index] = {
-          ...this.customers[index],
-          ...updates,
-          followUpCadence:
-            CADENCE[updates.category ?? this.customers[index].category] ?? CADENCE.Cold,
-        }
+        this.customers[index] = { ...this.customers[index], ...updates }
       }
 
       try {
@@ -98,6 +93,24 @@ export const useCustomerStore = defineStore('customers', {
         if (c) c.lastContactedAt = null
         this.error = e.message
       }
+    },
+
+    async setNextContactAt(id, dateIso) {
+      const c = this.customers.find((c) => c.id === id)
+      const prev = c?.nextContactAt ?? null
+      if (c) c.nextContactAt = dateIso
+      try {
+        await setNextContactAtService(id, dateIso)
+      } catch (e) {
+        if (c) c.nextContactAt = prev
+        this.error = e.message
+      }
+    },
+
+    async logContact(id, lastContactedIso, nextContactIso) {
+      await this.setLastContacted(id, lastContactedIso)
+      await this.setNextContactAt(id, nextContactIso)
+      await this.addFeedback(id, 'Contacted')
     },
 
     async fetchFeedback(customerId) {

--- a/Bold_Vision_CRM/src/utils/followUp.js
+++ b/Bold_Vision_CRM/src/utils/followUp.js
@@ -1,31 +1,105 @@
-const CADENCE_MONTHS = { Hot: 3, Warm: 6, Cold: 12 }
+// Cadence defaults — single source of truth.
+// Change values here to adjust all quick-pick buttons across the app.
+export const CADENCE_MONTHS = { Hot: 3, Warm: 6, Cold: 12 }
 
 export function cadenceMonths(category) {
-  return CADENCE_MONTHS[category] ?? 12
+  return CADENCE_MONTHS[category] ?? CADENCE_MONTHS.Cold
 }
 
 export function cadenceLabel(category) {
-  const months = cadenceMonths(category)
-  return `Every ${months} months (${category})`
+  const m = cadenceMonths(category)
+  return `+${m} month${m === 1 ? '' : 's'}`
 }
 
-// Positive = days past due. Infinity = never contacted. Negative = days until due.
-export function daysOverdue(customer, today = new Date()) {
-  if (!customer.lastContactedAt) return Infinity
-  const lastContacted = new Date(customer.lastContactedAt)
-  const dueDate = new Date(lastContacted)
-  dueDate.setMonth(dueDate.getMonth() + cadenceMonths(customer.category))
-  const diffMs = today - dueDate
-  return Math.floor(diffMs / (1000 * 60 * 60 * 24))
+// ── Status ─────────────────────────────────────────────────────────────────
+
+// Returns one of: 'never-contacted' | 'unscheduled' | 'overdue' | 'approaching' | 'up-to-date'
+export function customerStatus(customer, today = new Date()) {
+  if (!customer.nextContactAt) {
+    return customer.lastContactedAt ? 'unscheduled' : 'never-contacted'
+  }
+  const next = new Date(customer.nextContactAt)
+  const diffDays = Math.ceil((next - today) / (1000 * 60 * 60 * 24))
+  if (diffDays < 0) return 'overdue'
+  if (diffDays <= 30) return 'approaching'
+  return 'up-to-date'
+}
+
+// Days until next contact (negative = past due). null if no schedule set.
+export function daysUntilContact(customer, today = new Date()) {
+  if (!customer.nextContactAt) return null
+  const next = new Date(customer.nextContactAt)
+  return Math.ceil((next - today) / (1000 * 60 * 60 * 24))
 }
 
 export function isOverdue(customer, today = new Date()) {
-  const days = daysOverdue(customer, today)
-  return days === Infinity || days >= 0
+  return customerStatus(customer, today) === 'overdue'
 }
 
-// Needs attention: overdue OR within 30 days of due date
 export function needsAttention(customer, today = new Date()) {
-  const days = daysOverdue(customer, today)
-  return days === Infinity || days >= -30
+  const s = customerStatus(customer, today)
+  return s !== 'up-to-date'
+}
+
+// ── Week bucketing ──────────────────────────────────────────────────────────
+
+function startOfDay(date) {
+  const d = new Date(date)
+  d.setHours(0, 0, 0, 0)
+  return d
+}
+
+function isSameDay(a, b) {
+  return (
+    a.getFullYear() === b.getFullYear() &&
+    a.getMonth() === b.getMonth() &&
+    a.getDate() === b.getDate()
+  )
+}
+
+// Returns array of 7 Date objects starting from today (for Kanban column headers).
+export function weekDays(today = new Date()) {
+  const base = startOfDay(today)
+  return Array.from({ length: 7 }, (_, i) => {
+    const d = new Date(base)
+    d.setDate(d.getDate() + i)
+    return d
+  })
+}
+
+// Buckets customers into { overdue, unscheduled, days } for the week Kanban.
+// 'days' is an array of { date, customers } for today through today+6.
+// Customers beyond 7 days are not shown (they will appear as time passes).
+export function bucketCustomersForWeek(customers, today = new Date()) {
+  const todayStart = startOfDay(today)
+  const weekEnd = new Date(todayStart)
+  weekEnd.setDate(weekEnd.getDate() + 7)
+
+  const overdue = []
+  const unscheduled = []
+  const days = weekDays(today).map((date) => ({ date, customers: [] }))
+
+  for (const c of customers) {
+    if (!c.nextContactAt) {
+      unscheduled.push(c)
+      continue
+    }
+    const next = new Date(c.nextContactAt)
+    if (next < todayStart) {
+      overdue.push(c)
+    } else if (next < weekEnd) {
+      const bucket = days.find((d) => isSameDay(d.date, next))
+      if (bucket) bucket.customers.push(c)
+    }
+    // Beyond this week — not shown until they roll into the window
+  }
+
+  // Overdue: longest overdue first (oldest next_contact_at first)
+  overdue.sort((a, b) => new Date(a.nextContactAt) - new Date(b.nextContactAt))
+  // Each day bucket: earliest appointment first
+  for (const d of days) {
+    d.customers.sort((a, b) => new Date(a.nextContactAt) - new Date(b.nextContactAt))
+  }
+
+  return { overdue, unscheduled, days }
 }

--- a/Bold_Vision_CRM/src/views/CustomerDetailView.vue
+++ b/Bold_Vision_CRM/src/views/CustomerDetailView.vue
@@ -1,4 +1,4 @@
-<template>
+﻿<template>
   <v-container fluid class="py-4">
     <!-- Breadcrumbs -->
     <v-breadcrumbs :items="breadcrumbs" class="mb-4" />
@@ -130,70 +130,88 @@
         </v-card>
       </v-col>
 
-      <!-- Right side: follow-up / summary -->
+      <!-- Right side: follow-up -->
       <v-col cols="12" md="4">
-        <!-- Follow-up scheduler -->
         <v-card elevation="2" class="mb-4">
-          <v-card-title>Follow-up schedule</v-card-title>
+          <v-card-title class="d-flex align-center justify-space-between">
+            <span>Follow-up</span>
+            <v-chip :color="statusChip.color" size="small" variant="tonal">{{ statusChip.label }}</v-chip>
+          </v-card-title>
+
           <v-card-text>
-            <v-text-field
-              v-model="editable.lastContactedAt"
-              label="Last contacted (ISO or date string)"
-              hint="Will be replaced with date picker later"
-            />
+            <!-- Last contacted -->
+            <p class="text-caption text-medium-emphasis mb-1">Last contacted</p>
+            <div class="d-flex align-center gap-2 mb-4">
+              <v-text-field
+                :model-value="lastContactedDateInput"
+                type="datetime-local"
+                density="compact"
+                hide-details
+                variant="outlined"
+                @change="onLastContactedChange"
+              />
+              <v-btn size="small" variant="tonal" color="primary" @click="setLastContactToNow">Now</v-btn>
+            </div>
+
+            <!-- Next contact -->
+            <p class="text-caption text-medium-emphasis mb-1">Next contact</p>
+            <div class="d-flex align-center gap-2 mb-2">
+              <v-text-field
+                v-model="nextContactInput"
+                type="datetime-local"
+                density="compact"
+                hide-details
+                variant="outlined"
+              />
+              <v-btn size="small" variant="tonal" color="primary" @click="saveNextContact">Set</v-btn>
+              <v-btn size="small" variant="tonal" color="error" icon="mdi-close" @click="clearNextContact" />
+            </div>
             <v-btn
               size="small"
-              color="primary"
               variant="outlined"
-              class="mt-2 mb-4"
-              @click="setLastContactToToday"
+              color="secondary"
+              class="mb-4"
+              :disabled="!editable.category"
+              @click="applyDefaultCadence"
             >
-              Set to today
+              {{ quickPickLabel }}
             </v-btn>
-
-            <v-select
-              v-model="editable.followUpCadence"
-              :items="['Every 3 months (Hot)', 'Every 6 months (Warm)', 'Every 12 months (Cold)']"
-              label="Follow-up cadence"
-            />
-
-            <p class="text-body-2 mt-3">
-              In the full system this section will calculate the next contact date and feed into the
-              “Customers to contact today” view.
-            </p>
           </v-card-text>
+
+          <v-card-actions class="px-4 pb-4">
+            <v-btn
+              color="primary"
+              variant="flat"
+              prepend-icon="mdi-check-circle-outline"
+              block
+              @click="markContactedDialog = true"
+            >
+              Mark contacted
+            </v-btn>
+          </v-card-actions>
         </v-card>
-
-        <!-- Quick summary card -->
-        <v-card elevation="2" class="mb-4">
-          <v-card-title>Quick summary</v-card-title>
-          <v-card-text>
-            <p class="text-body-2 mb-1">
-              Category:
-              <v-chip
-                v-if="editable.category"
-                :color="categoryColor(editable.category)"
-                text-color="white"
-                size="small"
-              >
-                {{ editable.category }}
-              </v-chip>
-            </p>
-
-            <p class="text-body-2 mb-1">
-              Last contacted:
-              <strong>{{ lastContactedLabel }}</strong>
-            </p>
-
-            <p class="text-body-2">
-              Preferred channel:
-              <strong>{{ editable.channel || 'N/A' }}</strong>
-            </p>
-          </v-card-text>
-        </v-card>
-
       </v-col>
     </v-row>
+
+    <!-- Mark contacted dialog -->
+    <v-dialog v-model="markContactedDialog" max-width="400">
+      <v-card>
+        <v-card-title>Mark as contacted</v-card-title>
+        <v-card-text>
+          <p class="text-body-2 mb-4">Last contacted will be set to now.</p>
+          <p class="text-body-2 font-weight-medium mb-2">When should we contact next?</p>
+          <v-text-field v-model="mcNextDate" label="Date & time" type="datetime-local" class="mb-2" />
+          <v-btn variant="outlined" size="small" color="secondary" class="mb-3" @click="mcApplyDefault">
+            {{ quickPickLabel }}
+          </v-btn>
+          <v-checkbox v-model="mcSkip" label="Skip - don't schedule next contact" density="compact" hide-details />
+        </v-card-text>
+        <v-card-actions class="justify-end">
+          <v-btn variant="text" @click="markContactedDialog = false">Cancel</v-btn>
+          <v-btn color="primary" variant="flat" @click="confirmMarkContacted">Confirm</v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
 
     <!-- Interested properties (full-width) -->
     <CustomerInterestsPanel :customer-id="id" class="mt-2" />
@@ -201,9 +219,10 @@
 </template>
 
 <script setup>
-import { ref, computed, onMounted } from 'vue'
+import { ref, computed, watch, onMounted } from 'vue'
 import { useRoute } from 'vue-router'
 import { useCustomerStore } from '../stores/customerStore'
+import { customerStatus, daysUntilContact, cadenceMonths, cadenceLabel } from '../utils/followUp'
 import CustomerInterestsPanel from '../components/customer/CustomerInterestsPanel.vue'
 
 const route = useRoute()
@@ -211,11 +230,9 @@ const store = useCustomerStore()
 
 const id = route.params.id
 
-// locate customer from store
 const original = computed(() => store.customers.find((c) => c.id === id))
 const customerFound = computed(() => !!original.value)
 
-// local editable copy (skeleton fields; adjust to match your store)
 const editable = ref({
   id,
   name: '',
@@ -224,25 +241,21 @@ const editable = ref({
   category: 'Cold',
   channel: 'Call',
   notes: '',
-  lastContactedAt: '',
-  followUpCadence: '',
+  lastContactedAt: null,
+  nextContactAt: null,
 })
 
-// initialise from store if found
 if (original.value) {
-  editable.value = {
-    ...editable.value,
-    ...original.value,
-  }
+  editable.value = { ...editable.value, ...original.value }
 }
 
-// breadcrumbs
+// ── Derived / display ───────────────────────────────────────────────────────
+
 const breadcrumbs = computed(() => [
   { title: 'Existing customers', to: { name: 'customers' } },
   { title: editable.value.name || 'Customer details', disabled: true },
 ])
 
-// profile initials
 const initials = computed(() => {
   if (!editable.value.name) return '?'
   return editable.value.name
@@ -254,34 +267,126 @@ const initials = computed(() => {
 })
 
 function categoryColor(category) {
-  switch (category) {
-    case 'Hot':
-      return 'red'
-    case 'Warm':
-      return 'orange'
-    default:
-      return 'blue'
-  }
+  if (category === 'Hot') return 'red'
+  if (category === 'Warm') return 'orange'
+  return 'blue'
 }
 
-function formatDate(isoOrString) {
-  if (!isoOrString) return 'N/A'
-  const d = new Date(isoOrString)
-  if (Number.isNaN(d.getTime())) return isoOrString
-  return d.toLocaleDateString()
+function formatDate(iso) {
+  if (!iso) return 'N/A'
+  const d = new Date(iso)
+  return Number.isNaN(d.getTime()) ? iso : d.toLocaleDateString('en-AU')
 }
 
 const lastContactedLabel = computed(() =>
   editable.value.lastContactedAt ? formatDate(editable.value.lastContactedAt) : 'Not set',
 )
 
-const feedbackEntries = computed(() => store.feedback[id] ?? [])
+// ── Follow-up card computeds ────────────────────────────────────────────────
 
+const statusChip = computed(() => {
+  const status = customerStatus(editable.value)
+  if (status === 'never-contacted') return { label: 'Never contacted', color: 'error' }
+  if (status === 'unscheduled')     return { label: 'No schedule', color: 'warning' }
+  if (status === 'overdue') {
+    const d = Math.abs(daysUntilContact(editable.value))
+    return { label: `${d}d overdue`, color: 'error' }
+  }
+  if (status === 'approaching') {
+    const d = daysUntilContact(editable.value)
+    return { label: `Due in ${d}d`, color: 'warning' }
+  }
+  return { label: 'Up to date', color: 'success' }
+})
+
+const lastContactedDateInput = computed(() => {
+  if (!editable.value.lastContactedAt) return ''
+  return new Date(editable.value.lastContactedAt).toISOString().slice(0, 16)
+})
+
+const nextContactInput = ref(
+  editable.value.nextContactAt ? new Date(editable.value.nextContactAt).toISOString().slice(0, 16) : ''
+)
+
+watch(
+  () => editable.value.nextContactAt,
+  (val) => {
+    nextContactInput.value = val ? new Date(val).toISOString().slice(0, 16) : ''
+  }
+)
+
+const quickPickLabel = computed(() => {
+  if (!editable.value.category) return 'Set default'
+  return `${cadenceLabel(editable.value.category)} (${editable.value.category} default)`
+})
+
+// ── Follow-up actions ────────────────────────────────────────────────────────
+
+async function onLastContactedChange(e) {
+  const val = e.target.value
+  if (!val) return
+  const iso = new Date(val).toISOString()
+  editable.value.lastContactedAt = iso
+  await store.setLastContacted(id, iso)
+}
+
+async function saveNextContact() {
+  const val = nextContactInput.value
+  const iso = val ? new Date(val).toISOString() : null
+  editable.value.nextContactAt = iso
+  await store.setNextContactAt(id, iso)
+}
+
+async function setLastContactToNow() {
+  const iso = new Date().toISOString()
+  editable.value.lastContactedAt = iso
+  await store.setLastContacted(id, iso)
+}
+
+async function clearNextContact() {
+  editable.value.nextContactAt = null
+  nextContactInput.value = ''
+  await store.setNextContactAt(id, null)
+}
+
+async function applyDefaultCadence() {
+  const next = new Date()
+  next.setMonth(next.getMonth() + cadenceMonths(editable.value.category))
+  const iso = next.toISOString()
+  editable.value.nextContactAt = iso
+  await store.setNextContactAt(id, iso)
+}
+
+// ── Mark contacted dialog ────────────────────────────────────────────────────
+
+const markContactedDialog = ref(false)
+const mcNextDate = ref('')
+const mcSkip = ref(false)
+
+function mcApplyDefault() {
+  const next = new Date()
+  next.setMonth(next.getMonth() + cadenceMonths(editable.value.category))
+  mcNextDate.value = next.toISOString().slice(0, 16)
+  mcSkip.value = false
+}
+
+async function confirmMarkContacted() {
+  const now = new Date().toISOString()
+  const nextIso = mcSkip.value || !mcNextDate.value ? null : new Date(mcNextDate.value).toISOString()
+  await store.logContact(id, now, nextIso)
+  editable.value.lastContactedAt = now
+  editable.value.nextContactAt = nextIso
+  markContactedDialog.value = false
+  mcNextDate.value = ''
+  mcSkip.value = false
+}
+
+// ── Feedback ─────────────────────────────────────────────────────────────────
+
+const feedbackEntries = computed(() => store.feedback[id] ?? [])
 const newFeedback = ref('')
 
-onMounted(() => {
-  store.fetchFeedback(id)
-})
+onMounted(() => store.fetchFeedback(id))
 
 async function addFeedback() {
   const note = newFeedback.value.trim()
@@ -290,13 +395,8 @@ async function addFeedback() {
   newFeedback.value = ''
 }
 
-function setLastContactToToday() {
-  const iso = new Date().toISOString()
-  editable.value.lastContactedAt = iso
-  store.setLastContacted(id, iso)
-}
+// ── Basic info save/reset ────────────────────────────────────────────────────
 
-// Actions
 function saveChanges() {
   if (!customerFound.value) return
   store.updateCustomer(id, { ...editable.value })
@@ -304,9 +404,6 @@ function saveChanges() {
 
 function resetChanges() {
   if (!original.value) return
-  editable.value = {
-    ...editable.value,
-    ...original.value,
-  }
+  editable.value = { ...editable.value, ...original.value }
 }
 </script>

--- a/Bold_Vision_CRM/src/views/CustomersView.vue
+++ b/Bold_Vision_CRM/src/views/CustomersView.vue
@@ -17,7 +17,6 @@
         <span>Phone</span>
         <span>Channel</span>
         <span>Category</span>
-        <span class="followup-col">Follow-up cadence</span>
         <span class="text-center">Actions</span>
       </div>
 
@@ -44,12 +43,6 @@
               class="category-chip"
             >
               {{ customer.category }}
-            </v-chip>
-          </div>
-          <div class="cell followup-col">
-            <span class="cell-label">Follow-up Cadence</span>
-            <v-chip size="small" variant="outlined" class="text-capitalize">
-              {{ customer.followUpCadence }}
             </v-chip>
           </div>
           <div class="cell actions">
@@ -299,7 +292,7 @@ function handleFilterClear() {
 .list-header,
 .list-row {
   display: grid;
-  grid-template-columns: 1.8fr 1fr 1fr 1fr 1.2fr 1fr;
+  grid-template-columns: 1.8fr 1fr 1fr 1fr 1fr;
   gap: 16px;
   padding: 16px clamp(12px, 2.5vw, 24px);
   align-items: center;
@@ -350,25 +343,6 @@ function handleFilterClear() {
 
 .actions {
   text-align: center;
-}
-
-.followup-col {
-  display: block;
-}
-
-.list-row .followup-col {
-  text-align: left;
-}
-
-@media (max-width: 1200px) {
-  .list-header,
-  .list-row {
-    grid-template-columns: 1.8fr 1fr 1fr 1fr 1fr;
-  }
-
-  .followup-col {
-    display: none;
-  }
 }
 
 .empty-state {

--- a/Bold_Vision_CRM/src/views/FollowUpsView.vue
+++ b/Bold_Vision_CRM/src/views/FollowUpsView.vue
@@ -1,82 +1,174 @@
 <template>
   <div class="followups">
-    <div class="followups-header mb-6">
-      <h2>Follow-ups</h2>
-      <p class="text-body-2 text-medium-emphasis mt-1">
-        {{ overdueCount }} customer{{ overdueCount === 1 ? '' : 's' }} overdue for contact
-      </p>
+    <div class="followups-header mb-4">
+      <div class="d-flex align-center justify-space-between flex-wrap gap-2">
+        <div>
+          <h2>Follow-ups</h2>
+          <p class="text-body-2 text-medium-emphasis mt-1">{{ weekRangeLabel }}</p>
+        </div>
+        <div class="d-flex gap-2">
+          <v-chip v-if="overdueCount" color="error" size="small" prepend-icon="mdi-alert-circle-outline">
+            {{ overdueCount }} overdue
+          </v-chip>
+          <v-chip v-if="unscheduledCount" color="warning" size="small" prepend-icon="mdi-calendar-remove-outline">
+            {{ unscheduledCount }} unscheduled
+          </v-chip>
+          <v-chip v-if="!overdueCount && !unscheduledCount" color="success" size="small" prepend-icon="mdi-check-circle-outline">
+            All caught up
+          </v-chip>
+        </div>
+      </div>
     </div>
 
-    <v-tabs v-model="activeTab" color="primary" class="mb-4">
-      <v-tab value="Hot">
-        <v-icon start>mdi-fire</v-icon>
-        Hot
-        <v-badge v-if="hot.length" :content="hot.length" color="red" inline class="ml-2" />
-      </v-tab>
-      <v-tab value="Warm">
-        <v-icon start>mdi-weather-sunny</v-icon>
-        Warm
-        <v-badge v-if="warm.length" :content="warm.length" color="orange" inline class="ml-2" />
-      </v-tab>
-      <v-tab value="Cold">
-        <v-icon start>mdi-snowflake</v-icon>
-        Cold
-        <v-badge v-if="cold.length" :content="cold.length" color="blue" inline class="ml-2" />
-      </v-tab>
-    </v-tabs>
-
-    <v-window v-model="activeTab">
-      <v-window-item v-for="(group, level) in { Hot: hot, Warm: warm, Cold: cold }" :key="level" :value="level">
-        <div v-if="group.length" class="followup-list">
-          <div
-            v-for="customer in group"
-            :key="customer.id"
-            class="followup-card"
-          >
-            <div class="followup-card__info">
-              <p class="followup-card__name">{{ customer.name }}</p>
-              <p class="followup-card__sub">{{ customer.phone || customer.email || 'No contact info' }}</p>
-            </div>
-
-            <div class="followup-card__status">
-              <v-chip
-                :color="overdueChipColor(customer)"
-                size="small"
-                variant="tonal"
-              >
-                {{ overdueLabel(customer) }}
-              </v-chip>
-            </div>
-
-            <div class="followup-card__actions">
-              <v-btn
-                size="small"
-                variant="outlined"
-                color="primary"
-                class="mr-2"
-                @click="markContacted(customer)"
-              >
-                Mark contacted
-              </v-btn>
-              <v-btn
-                size="small"
-                variant="tonal"
-                color="primary"
-                :to="`/customers/${customer.id}`"
-              >
-                View
-              </v-btn>
-            </div>
+    <!-- Kanban board -->
+    <div class="kanban-board">
+      <!-- Overdue column -->
+      <div
+        class="kanban-column kanban-column--overdue"
+        :class="{ 'kanban-column--over': dragOverColumn === 'overdue' }"
+        @dragover.prevent="dragOverColumn = 'overdue'"
+        @dragleave="dragOverColumn = null"
+        @drop.prevent="onDrop('overdue')"
+      >
+        <div class="kanban-column__header">
+          <span class="kanban-column__title">Overdue</span>
+          <v-chip size="x-small" color="error" variant="flat" class="ml-1">{{ overdue.length }}</v-chip>
+        </div>
+        <div class="kanban-column__cards">
+          <KanbanCard
+            v-for="c in overdue"
+            :key="c.id"
+            :customer="c"
+            @dragstart="onDragStart(c)"
+            @dragend="dragOverColumn = null"
+            @mark-contacted="openMarkContacted(c)"
+            @clear-schedule="clearSchedule(c)"
+          />
+          <div v-if="!overdue.length" class="kanban-empty-state">
+            <v-icon size="18" color="success">mdi-check-circle-outline</v-icon>
+            <span>All clear</span>
           </div>
         </div>
+      </div>
 
-        <div v-else class="empty-state">
-          <v-icon size="48" color="success" class="mb-3">mdi-check-circle-outline</v-icon>
-          <p class="text-body-1 font-weight-medium">All {{ level }} customers are up to date.</p>
-          <p class="text-body-2 text-medium-emphasis">No follow-ups needed right now.</p>
+      <!-- No schedule column -->
+      <div
+        class="kanban-column kanban-column--unscheduled"
+        :class="{ 'kanban-column--over': dragOverColumn === 'unscheduled' }"
+        @dragover.prevent="dragOverColumn = 'unscheduled'"
+        @dragleave="dragOverColumn = null"
+        @drop.prevent="onDrop('unscheduled')"
+      >
+        <div class="kanban-column__header">
+          <span class="kanban-column__title">No schedule</span>
+          <v-chip v-if="unscheduled.length" size="x-small" color="warning" variant="flat" class="ml-1">{{ unscheduled.length }}</v-chip>
         </div>
-      </v-window-item>
-    </v-window>
+        <div class="kanban-column__cards">
+          <KanbanCard
+            v-for="c in unscheduled"
+            :key="c.id"
+            :customer="c"
+            :show-status="true"
+            @dragstart="onDragStart(c)"
+            @dragend="dragOverColumn = null"
+            @mark-contacted="openMarkContacted(c)"
+            @clear-schedule="clearSchedule(c)"
+          />
+          <div v-if="!unscheduled.length" class="kanban-empty-state">
+            <v-icon size="18" color="success">mdi-check-circle-outline</v-icon>
+            <span>All scheduled</span>
+          </div>
+        </div>
+      </div>
+
+        <!-- Visual divider between special columns and day columns -->
+      <div class="kanban-divider" />
+
+      <!-- Day columns (today → today+6) -->
+      <div
+        v-for="bucket in days"
+        :key="bucket.date.toISOString()"
+        class="kanban-column"
+        :class="[
+          isToday(bucket.date) && 'kanban-column--today',
+          dragOverColumn === bucket.date.toDateString() && 'kanban-column--over'
+        ]"
+        @dragover.prevent="dragOverColumn = bucket.date.toDateString()"
+        @dragleave="dragOverColumn = null"
+        @drop.prevent="onDrop(bucket.date)"
+      >
+        <div class="kanban-column__header">
+          <span class="kanban-column__title">{{ formatDayLabel(bucket.date) }}</span>
+          <v-chip v-if="bucket.customers.length" size="x-small" color="primary" variant="flat" class="ml-1">{{ bucket.customers.length }}</v-chip>
+        </div>
+        <div class="kanban-column__cards">
+          <KanbanCard
+            v-for="c in bucket.customers"
+            :key="c.id"
+            :customer="c"
+            @dragstart="onDragStart(c)"
+            @dragend="dragOverColumn = null"
+            @mark-contacted="openMarkContacted(c)"
+            @clear-schedule="clearSchedule(c)"
+          />
+          <p v-if="!bucket.customers.length" class="kanban-empty">—</p>
+          <!-- drop zone visual when empty and dragging -->
+
+        </div>
+      </div>
+    </div>
+
+    <!-- Reschedule dialog -->
+    <v-dialog v-model="rescheduleDialog.open" max-width="380">
+      <v-card>
+        <v-card-title>Reschedule {{ rescheduleDialog.customer?.name }}</v-card-title>
+        <v-card-text>
+          <v-text-field
+            v-model="rescheduleDialog.date"
+            label="Date"
+            type="date"
+            class="mb-2"
+          />
+          <v-text-field
+            v-model="rescheduleDialog.time"
+            label="Time"
+            type="time"
+          />
+        </v-card-text>
+        <v-card-actions class="justify-end">
+          <v-btn variant="text" @click="rescheduleDialog.open = false">Cancel</v-btn>
+          <v-btn color="primary" variant="flat" @click="confirmReschedule">Confirm</v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+
+    <!-- Mark contacted dialog -->
+    <v-dialog v-model="markContactedDialog.open" max-width="400">
+      <v-card>
+        <v-card-title>Mark as contacted</v-card-title>
+        <v-card-text>
+          <p class="text-body-2 mb-4">
+            Last contacted will be set to now for <strong>{{ markContactedDialog.customer?.name }}</strong>.
+          </p>
+          <p class="text-body-2 font-weight-medium mb-2">When should we contact next?</p>
+          <v-text-field v-model="markContactedDialog.date" label="Date" type="date" class="mb-2" />
+          <v-text-field v-model="markContactedDialog.time" label="Time" type="time" class="mb-2" />
+          <v-btn
+            variant="tonal"
+            size="small"
+            class="mb-3"
+            @click="applyDefaultCadence"
+          >
+            {{ cadenceButtonLabel }}
+          </v-btn>
+          <v-checkbox v-model="markContactedDialog.skip" label="Skip — don't schedule next contact" density="compact" hide-details />
+        </v-card-text>
+        <v-card-actions class="justify-end">
+          <v-btn variant="text" @click="markContactedDialog.open = false">Cancel</v-btn>
+          <v-btn color="primary" variant="flat" @click="confirmMarkContacted">Confirm</v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
   </div>
 </template>
 
@@ -84,30 +176,125 @@
 import { ref, computed } from 'vue'
 import { useCustomerStore } from '../stores/customerStore'
 import { useCustomerFollowups } from '../composables/useCustomerFollowups'
-import { daysOverdue, isOverdue } from '../utils/followUp'
+import { cadenceMonths, cadenceLabel } from '../utils/followUp'
+import KanbanCard from '../components/followups/KanbanCard.vue'
 
 const store = useCustomerStore()
 const customers = computed(() => store.customers)
 
-const activeTab = ref('Hot')
+const { overdue, unscheduled, days, overdueCount, unscheduledCount } =
+  useCustomerFollowups(customers)
 
-const { hot, warm, cold, overdueCount } = useCustomerFollowups(customers)
+// ── Drag state ──────────────────────────────────────────────────────────────
+const dragCustomer = ref(null)
+const dragOverColumn = ref(null)
 
-function overdueLabel(customer) {
-  const days = daysOverdue(customer)
-  if (days === Infinity) return 'Never contacted'
-  if (days >= 0) return `${days} day${days === 1 ? '' : 's'} overdue`
-  return `Due in ${Math.abs(days)} day${Math.abs(days) === 1 ? '' : 's'}`
+function onDragStart(customer) {
+  dragCustomer.value = customer
 }
 
-function overdueChipColor(customer) {
-  const days = daysOverdue(customer)
-  if (isOverdue(customer) || days === Infinity) return 'error'
-  return 'warning'
+function onDrop(target) {
+  dragOverColumn.value = null
+  if (!dragCustomer.value) return
+
+  if (target === 'overdue' || target === 'unscheduled') {
+    if (target === 'unscheduled') {
+      openRescheduleFor(dragCustomer.value, null)
+    }
+    dragCustomer.value = null
+    return
+  }
+
+  // target is a Date — open reschedule dialog with that date pre-filled
+  const c = dragCustomer.value
+  dragCustomer.value = null
+  openRescheduleFor(c, target)
 }
 
-async function markContacted(customer) {
-  await store.setLastContacted(customer.id, new Date().toISOString())
+// ── Reschedule dialog ───────────────────────────────────────────────────────
+const rescheduleDialog = ref({ open: false, customer: null, date: '', time: '' })
+
+function openRescheduleFor(customer, date) {
+  const existing = customer.nextContactAt ? new Date(customer.nextContactAt) : null
+  const targetDate = date ?? new Date()
+
+  rescheduleDialog.value = {
+    open: true,
+    customer,
+    date: toDateInput(targetDate),
+    time: existing ? toTimeInput(existing) : '09:00',
+  }
+}
+
+async function confirmReschedule() {
+  const { customer, date, time } = rescheduleDialog.value
+  if (!date) { rescheduleDialog.value.open = false; return }
+  const iso = new Date(`${date}T${time || '09:00'}`).toISOString()
+  await store.setNextContactAt(customer.id, iso)
+  rescheduleDialog.value.open = false
+}
+
+async function clearSchedule(customer) {
+  await store.setNextContactAt(customer.id, null)
+}
+
+// ── Mark contacted dialog ───────────────────────────────────────────────────
+const markContactedDialog = ref({ open: false, customer: null, date: '', time: '', skip: false })
+
+function openMarkContacted(customer) {
+  markContactedDialog.value = { open: true, customer, date: '', time: '', skip: false }
+}
+
+const cadenceButtonLabel = computed(() => {
+  const c = markContactedDialog.value.customer
+  if (!c) return ''
+  return `${cadenceLabel(c.category)} (${c.category} default)`
+})
+
+function applyDefaultCadence() {
+  const c = markContactedDialog.value.customer
+  if (!c) return
+  const next = new Date()
+  next.setMonth(next.getMonth() + cadenceMonths(c.category))
+  markContactedDialog.value.date = toDateInput(next)
+  markContactedDialog.value.time = '09:00'
+  markContactedDialog.value.skip = false
+}
+
+async function confirmMarkContacted() {
+  const { customer, date, time, skip } = markContactedDialog.value
+  const now = new Date().toISOString()
+  const nextIso = skip || !date ? null : new Date(`${date}T${time || '09:00'}`).toISOString()
+  await store.logContact(customer.id, now, nextIso)
+  markContactedDialog.value.open = false
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+const weekRangeLabel = computed(() => {
+  const d = days.value
+  if (!d.length) return ''
+  const first = d[0].date
+  const last = d[d.length - 1].date
+  const fmt = (date) => date.toLocaleDateString('en-AU', { day: 'numeric', month: 'short' })
+  return `${fmt(first)} – ${fmt(last)}, ${first.getFullYear()}`
+})
+
+function toDateInput(d) {
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+}
+
+function toTimeInput(d) {
+  return `${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}`
+}
+
+function isToday(date) {
+  const t = new Date()
+  return date.getFullYear() === t.getFullYear() && date.getMonth() === t.getMonth() && date.getDate() === t.getDate()
+}
+
+function formatDayLabel(date) {
+  if (isToday(date)) return 'Today'
+  return date.toLocaleDateString('en-AU', { weekday: 'short', day: 'numeric', month: 'short' })
 }
 </script>
 
@@ -117,75 +304,91 @@ async function markContacted(customer) {
   font-weight: 700;
 }
 
-.followup-list {
+.kanban-board {
+  display: flex;
+  gap: 12px;
+  overflow-x: auto;
+  align-items: stretch;
+  padding-bottom: 16px;
+  min-height: calc(100vh - 220px);
+}
+
+.kanban-divider {
+  flex: 0 0 1px;
+  background: #e2e8f0;
+  align-self: stretch;
+  margin: 0 4px;
+}
+
+.kanban-column {
+  flex: 0 0 200px;
+  min-height: 240px;
+  background: #f8fafc;
+  border-radius: 10px;
+  border: 2px solid transparent;
+  transition: border-color 0.15s, background 0.15s;
+}
+
+.kanban-column--today {
+  background: #f0f9ff;
+  border-color: #bae6fd;
+}
+
+.kanban-column--today .kanban-column__title {
+  color: #0284c7;
+}
+
+.kanban-column--over {
+  border-color: #6366f1 !important;
+  background: #eef2ff;
+}
+
+.kanban-column--overdue {
+  background: #fef2f2;
+}
+
+.kanban-column--unscheduled {
+  background: #fffbeb;
+}
+
+.kanban-column__header {
+  display: flex;
+  align-items: center;
+  padding: 10px 12px 8px;
+  border-bottom: 1px solid #e2e8f0;
+}
+
+.kanban-column__title {
+  font-size: 0.78rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: #475569;
+  flex: 1;
+}
+
+.kanban-column__cards {
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: 8px;
+  padding: 10px 8px;
 }
 
-.followup-card {
-  display: grid;
-  grid-template-columns: 1fr auto auto;
-  align-items: center;
-  gap: 16px;
-  padding: 14px 20px;
-  background: white;
-  border-radius: 12px;
-  border: 1px solid #e2e8f0;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06);
-}
-
-.followup-card__name {
-  font-weight: 600;
-  font-size: 0.95rem;
-  margin: 0 0 2px;
-}
-
-.followup-card__sub {
-  font-size: 0.82rem;
-  color: #64748b;
+.kanban-empty {
+  font-size: 0.75rem;
+  color: #cbd5e1;
+  text-align: center;
+  padding: 16px 0;
   margin: 0;
 }
 
-.followup-card__status {
-  white-space: nowrap;
-}
-
-.followup-card__actions {
+.kanban-empty-state {
   display: flex;
+  flex-direction: column;
   align-items: center;
-  white-space: nowrap;
-}
-
-.empty-state {
-  padding: 64px 24px;
-  text-align: center;
-  color: #475569;
-}
-
-@media (max-width: 640px) {
-  .followup-card {
-    grid-template-columns: 1fr auto;
-    grid-template-rows: auto auto;
-  }
-
-  .followup-card__status {
-    grid-column: 2;
-    grid-row: 1;
-  }
-
-  .followup-card__info {
-    grid-column: 1;
-    grid-row: 1;
-  }
-
-  .followup-card__actions {
-    grid-column: 1 / -1;
-    grid-row: 2;
-  }
-
-  .followup-card__actions .v-btn {
-    flex: 1;
-  }
+  gap: 4px;
+  padding: 16px 0;
+  font-size: 0.75rem;
+  color: #64748b;
 }
 </style>

--- a/Bold_Vision_CRM/src/views/HomeView.vue
+++ b/Bold_Vision_CRM/src/views/HomeView.vue
@@ -8,63 +8,41 @@
     </div>
 
     <!-- Follow-up summary -->
-    <v-card elevation="4" class="mb-6">
+    <v-card elevation="4" class="mb-4">
       <v-card-title class="d-flex align-center">
         <v-icon class="mr-2" color="primary">mdi-bell-ring-outline</v-icon>
-        Follow-ups needed
+        Follow-ups
       </v-card-title>
 
       <v-card-text>
-        <div v-if="overdueCount > 0">
-          <p class="text-body-1 mb-4">
-            <strong>{{ overdueCount }}</strong> customer{{ overdueCount === 1 ? '' : 's' }}
-            {{ overdueCount === 1 ? 'is' : 'are' }} overdue for contact.
-          </p>
-
-          <div class="category-summary">
-            <div
-              v-for="item in categorySummary"
-              :key="item.label"
-              class="category-summary__item"
-              :class="`category-summary__item--${item.label.toLowerCase()}`"
-            >
-              <p class="category-summary__count">{{ item.count }}</p>
-              <p class="category-summary__label">{{ item.label }}</p>
-            </div>
+        <div v-if="overdueCount > 0 || unscheduledCount > 0" class="summary-stats">
+          <div v-if="overdueCount > 0" class="summary-stat summary-stat--error">
+            <p class="summary-stat__count">{{ overdueCount }}</p>
+            <p class="summary-stat__label">Overdue</p>
+          </div>
+          <div v-if="unscheduledCount > 0" class="summary-stat summary-stat--warning">
+            <p class="summary-stat__count">{{ unscheduledCount }}</p>
+            <p class="summary-stat__label">Unscheduled</p>
+          </div>
+          <div v-if="todayCount > 0" class="summary-stat summary-stat--primary">
+            <p class="summary-stat__count">{{ todayCount }}</p>
+            <p class="summary-stat__label">Today</p>
           </div>
         </div>
 
         <div v-else class="all-clear">
           <v-icon size="40" color="success" class="mb-2">mdi-check-circle-outline</v-icon>
           <p class="text-body-1 font-weight-medium">All caught up!</p>
-          <p class="text-body-2 text-medium-emphasis">No customers are overdue for contact.</p>
+          <p class="text-body-2 text-medium-emphasis">No overdue or unscheduled customers.</p>
         </div>
       </v-card-text>
 
       <v-card-actions class="px-4 pb-4">
         <v-spacer />
-        <v-btn
-          color="primary"
-          variant="outlined"
-          :to="{ name: 'follow-ups' }"
-          append-icon="mdi-arrow-right"
-        >
+        <v-btn color="primary" variant="outlined" :to="{ name: 'follow-ups' }" append-icon="mdi-arrow-right">
           View follow-ups
         </v-btn>
       </v-card-actions>
-    </v-card>
-
-    <!-- Approaching (not yet overdue) -->
-    <v-card v-if="approachingCount > 0" elevation="2" variant="tonal" color="warning">
-      <v-card-text class="d-flex align-center">
-        <v-icon class="mr-3" color="warning">mdi-clock-outline</v-icon>
-        <span class="text-body-2">
-          <strong>{{ approachingCount }}</strong> more customer{{ approachingCount === 1 ? '' : 's' }}
-          approaching their due date in the next 30 days.
-        </span>
-        <v-spacer />
-        <v-btn size="small" variant="text" :to="{ name: 'follow-ups' }">View</v-btn>
-      </v-card-text>
     </v-card>
   </div>
 </template>
@@ -73,13 +51,11 @@
 import { computed } from 'vue'
 import { useCustomerStore } from '../stores/customerStore'
 import { useCustomerFollowups } from '../composables/useCustomerFollowups'
-import { isOverdue } from '../utils/followUp'
 
 const store = useCustomerStore()
 const customers = computed(() => store.customers)
 
-const { hot, warm, cold, overdueCount, hotOverdueCount, warmOverdueCount, coldOverdueCount } =
-  useCustomerFollowups(customers)
+const { overdueCount, unscheduledCount, days } = useCustomerFollowups(customers)
 
 const today = new Date().toLocaleDateString('en-AU', {
   weekday: 'long',
@@ -88,15 +64,7 @@ const today = new Date().toLocaleDateString('en-AU', {
   day: 'numeric',
 })
 
-const categorySummary = computed(() => [
-  { label: 'Hot', count: hotOverdueCount.value },
-  { label: 'Warm', count: warmOverdueCount.value },
-  { label: 'Cold', count: coldOverdueCount.value },
-].filter((item) => item.count > 0))
-
-const approachingCount = computed(() =>
-  [...hot.value, ...warm.value, ...cold.value].filter((c) => !isOverdue(c)).length,
-)
+const todayCount = computed(() => days.value[0]?.customers.length ?? 0)
 </script>
 
 <style scoped>
@@ -105,13 +73,13 @@ const approachingCount = computed(() =>
   font-weight: 700;
 }
 
-.category-summary {
+.summary-stats {
   display: flex;
   gap: 16px;
   flex-wrap: wrap;
 }
 
-.category-summary__item {
+.summary-stat {
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -119,32 +87,20 @@ const approachingCount = computed(() =>
   padding: 16px 24px;
   border-radius: 12px;
   min-width: 90px;
-  background: #f1f5f9;
 }
 
-.category-summary__item--hot {
-  background: #fee2e2;
-  color: #991b1b;
-}
+.summary-stat--error   { background: #fee2e2; color: #991b1b; }
+.summary-stat--warning { background: #ffedd5; color: #9a3412; }
+.summary-stat--primary { background: #dbeafe; color: #1e3a8a; }
 
-.category-summary__item--warm {
-  background: #ffedd5;
-  color: #9a3412;
-}
-
-.category-summary__item--cold {
-  background: #dbeafe;
-  color: #1e3a8a;
-}
-
-.category-summary__count {
+.summary-stat__count {
   font-size: 2rem;
   font-weight: 700;
   margin: 0;
   line-height: 1;
 }
 
-.category-summary__label {
+.summary-stat__label {
   font-size: 0.8rem;
   font-weight: 600;
   margin: 4px 0 0;

--- a/supabase/migrations/0003_customer_next_contact_at.sql
+++ b/supabase/migrations/0003_customer_next_contact_at.sql
@@ -1,0 +1,17 @@
+-- ─────────────────────────────────────────────────────────────────────────────
+-- Phase 5: customers.next_contact_at
+-- Agency-managed "when to follow up next" date+time. Source of truth for
+-- overdue/approaching/no-schedule status. Nullable; no backfill — agents will
+-- populate manually as they review each customer.
+-- ─────────────────────────────────────────────────────────────────────────────
+
+alter table public.customers
+  add column if not exists next_contact_at timestamptz;
+
+-- Index for Follow-ups Kanban range queries (week/month buckets).
+create index if not exists customers_next_contact_at_idx
+  on public.customers (next_contact_at)
+  where next_contact_at is not null;
+
+-- Note: table-level GRANT on public.customers (from 0001_init.sql) already
+-- covers this new column — no extra grant needed.


### PR DESCRIPTION
…View wired

- Add next_contact_at column (migration 0003) as agency-managed scheduling source of truth
- Rewrite FollowUpsView as 9-column Kanban (Overdue | No schedule | Today + 6 rolling days)
- Drag-and-drop between columns opens reschedule dialog with date pre-filled
- Mark contacted dialog with cadence quick-pick (+3/6/12 months for Hot/Warm/Cold)
- Wire CustomerDetailView Follow-up card: Last/Next contact pickers, Set button, status chip
- Auto-add Contacted entry to interaction history on Mark contacted
- CADENCE_MONTHS single source of truth in followUp.js
- Remove dead followUpCadence field and Follow-up cadence column from customers list
- Update HomeView dashboard to show Overdue / Unscheduled / Today counts