### PR TITLE
Phase 6: Telegram broadcast + bot enrollment

### DIFF
--- a/Bold_Vision_CRM/src/App.vue
+++ b/Bold_Vision_CRM/src/App.vue
@@ -59,6 +59,12 @@
               title="Follow-ups"
               rounded="lg"
             />
+            <v-list-item
+              :to="{ name: 'messages' }"
+              prepend-icon="mdi-message-text-outline"
+              title="Broadcasts"
+              rounded="lg"
+            />
           </v-list>
 
           <v-divider class="my-4" />

--- a/Bold_Vision_CRM/src/components/properties/BroadcastPanel.vue
+++ b/Bold_Vision_CRM/src/components/properties/BroadcastPanel.vue
@@ -1,0 +1,230 @@
+<template>
+  <v-card v-bind="$attrs" elevation="4">
+    <v-card-title class="d-flex align-center">
+      <v-icon class="mr-2" color="primary">mdi-send</v-icon>
+      Broadcast via Telegram
+    </v-card-title>
+
+    <v-card-text>
+      <!-- Audience selector -->
+      <p class="text-caption text-medium-emphasis mb-2">Audience</p>
+      <div class="d-flex gap-2 flex-wrap mb-4">
+        <v-chip
+          v-for="opt in audienceOptions"
+          :key="opt.value"
+          :color="selectedAudience === opt.value ? 'primary' : undefined"
+          :variant="selectedAudience === opt.value ? 'flat' : 'outlined'"
+          class="cursor-pointer"
+          @click="selectedAudience = opt.value"
+        >
+          {{ opt.label }}
+          <span class="ml-1 text-caption">({{ audienceCount(opt.value) }})</span>
+        </v-chip>
+      </div>
+
+      <!-- Enrolled count notice -->
+      <v-alert
+        v-if="eligibleRecipients.length === 0"
+        type="warning"
+        variant="tonal"
+        density="compact"
+        class="mb-4"
+      >
+        No enrolled Telegram customers in this group. Go to a customer profile to share their enrollment link.
+      </v-alert>
+      <p v-else class="text-caption text-medium-emphasis mb-4">
+        {{ eligibleRecipients.length }} enrolled Telegram
+        {{ eligibleRecipients.length === 1 ? 'customer' : 'customers' }} will receive this message.
+      </p>
+
+      <!-- Message body -->
+      <v-textarea
+        v-model="messageBody"
+        label="Message"
+        rows="5"
+        auto-grow
+        variant="outlined"
+        class="mb-2"
+      />
+      <p class="text-caption text-medium-emphasis mb-4">
+        You can edit this before sending.
+      </p>
+    </v-card-text>
+
+    <v-card-actions class="px-4 pb-4">
+      <v-spacer />
+      <v-btn
+        color="primary"
+        variant="flat"
+        prepend-icon="mdi-send"
+        :disabled="eligibleRecipients.length === 0 || !messageBody.trim()"
+        @click="confirmDialog = true"
+      >
+        Send to {{ eligibleRecipients.length }}
+      </v-btn>
+    </v-card-actions>
+
+    <!-- Recent broadcasts -->
+    <template v-if="recentBroadcasts.length">
+      <v-divider />
+      <v-card-text>
+        <p class="text-caption text-medium-emphasis text-uppercase font-weight-bold mb-3">Recent broadcasts</p>
+        <div v-for="b in recentBroadcasts" :key="b.id" class="mb-3">
+          <div class="d-flex align-center justify-space-between mb-1">
+            <span class="text-caption text-medium-emphasis">{{ formatDate(b.sentAt) }}</span>
+            <div class="d-flex gap-2">
+              <v-chip size="x-small" color="success" variant="tonal">{{ b.sentCount }} sent</v-chip>
+              <v-chip v-if="b.failedCount" size="x-small" color="error" variant="tonal">{{ b.failedCount }} failed</v-chip>
+            </div>
+          </div>
+          <p class="text-body-2 text-truncate">{{ b.body }}</p>
+          <p class="text-caption text-medium-emphasis">To: {{ b.audienceFilter }}</p>
+          <v-divider class="mt-2" />
+        </div>
+      </v-card-text>
+    </template>
+  </v-card>
+
+  <!-- Confirm dialog -->
+  <v-dialog v-model="confirmDialog" max-width="440">
+    <v-card>
+      <v-card-title>Confirm broadcast</v-card-title>
+      <v-card-text>
+        <p class="text-body-2 mb-2">
+          Sending to <strong>{{ eligibleRecipients.length }}</strong>
+          {{ selectedAudience === 'All' ? '' : selectedAudience }}
+          Telegram {{ eligibleRecipients.length === 1 ? 'customer' : 'customers' }}.
+        </p>
+
+        <!-- Recipient preview -->
+        <v-expansion-panels variant="accordion" class="mb-4">
+          <v-expansion-panel title="Preview recipients">
+            <v-expansion-panel-text>
+              <div v-for="c in eligibleRecipients" :key="c.id" class="text-body-2 py-1">
+                {{ c.name }}
+                <v-chip size="x-small" :color="categoryColor(c.category)" class="ml-1">{{ c.category }}</v-chip>
+              </div>
+            </v-expansion-panel-text>
+          </v-expansion-panel>
+        </v-expansion-panels>
+
+        <v-card variant="tonal" class="pa-3 text-body-2" style="white-space: pre-wrap;">{{ messageBody }}</v-card>
+      </v-card-text>
+      <v-card-actions class="justify-end">
+        <v-btn variant="text" :disabled="sending" @click="confirmDialog = false">Cancel</v-btn>
+        <v-btn color="primary" variant="flat" :loading="sending" @click="send">Send</v-btn>
+      </v-card-actions>
+    </v-card>
+  </v-dialog>
+
+  <!-- Result snackbar -->
+  <v-snackbar v-model="snackbar.show" :color="snackbar.color" timeout="4000">
+    {{ snackbar.text }}
+  </v-snackbar>
+</template>
+
+<script setup>
+import { ref, computed, onMounted } from 'vue'
+
+defineOptions({ inheritAttrs: false })
+import { useCustomerStore } from '../../stores/customerStore'
+import { createBroadcast, listBroadcastsForProperty } from '../../services/messagesService'
+
+const props = defineProps({
+  property: { type: Object, required: true },
+})
+
+const customerStore = useCustomerStore()
+
+const selectedAudience = ref('All')
+const messageBody      = ref('')
+const confirmDialog    = ref(false)
+const sending          = ref(false)
+const recentBroadcasts = ref([])
+
+const snackbar = ref({ show: false, text: '', color: 'success' })
+
+const audienceOptions = [
+  { label: 'All',  value: 'All'  },
+  { label: 'Hot',  value: 'Hot'  },
+  { label: 'Warm', value: 'Warm' },
+  { label: 'Cold', value: 'Cold' },
+]
+
+// Customers eligible for broadcast: must have telegram_chat_id
+const telegramCustomers = computed(() =>
+  customerStore.customers.filter((c) => c.telegramChatId)
+)
+
+function audienceCount(filter) {
+  if (filter === 'All') return telegramCustomers.value.length
+  return telegramCustomers.value.filter((c) => c.category === filter).length
+}
+
+const eligibleRecipients = computed(() => {
+  if (selectedAudience.value === 'All') return telegramCustomers.value
+  return telegramCustomers.value.filter((c) => c.category === selectedAudience.value)
+})
+
+function categoryColor(cat) {
+  if (cat === 'Hot')  return 'red'
+  if (cat === 'Warm') return 'orange'
+  return 'blue'
+}
+
+function formatDate(iso) {
+  return new Date(iso).toLocaleString('en-AU', {
+    day: 'numeric', month: 'short', hour: '2-digit', minute: '2-digit', hour12: true,
+  })
+}
+
+function buildDefaultMessage() {
+  const p = props.property
+  const lines = [`New Listing: ${p.address}${p.suburb ? ', ' + p.suburb : ''}`]
+  if (p.priceGuide)  lines.push(`Price: ${p.priceGuide}`)
+  const details = []
+  if (p.bedrooms)   details.push(`${p.bedrooms} bed`)
+  if (p.bathrooms)  details.push(`${p.bathrooms} bath`)
+  if (p.carSpaces)  details.push(`${p.carSpaces} car`)
+  if (details.length) lines.push(details.join(' | '))
+  if (p.description) lines.push('', p.description)
+  lines.push('', 'Contact Bold Vision Properties for more information.')
+  return lines.join('\n')
+}
+
+async function send() {
+  sending.value = true
+  try {
+    const result = await createBroadcast({
+      propertyId: props.property.id,
+      body: messageBody.value,
+      audienceFilter: selectedAudience.value,
+      customers: eligibleRecipients.value,
+    })
+    confirmDialog.value = false
+    snackbar.value = {
+      show: true,
+      text: `Sent to ${result.sent} customer${result.sent === 1 ? '' : 's'}${result.failed ? ` (${result.failed} failed)` : ''}.`,
+      color: result.failed ? 'warning' : 'success',
+    }
+    await loadBroadcasts()
+  } catch (e) {
+    snackbar.value = { show: true, text: `Error: ${e.message}`, color: 'error' }
+  } finally {
+    sending.value = false
+  }
+}
+
+async function loadBroadcasts() {
+  try {
+    recentBroadcasts.value = await listBroadcastsForProperty(props.property.id)
+  } catch {
+    // non-critical — silent fail
+  }
+}
+
+onMounted(() => {
+  messageBody.value = buildDefaultMessage()
+  loadBroadcasts()
+})
+</script>

--- a/Bold_Vision_CRM/src/router/index.js
+++ b/Bold_Vision_CRM/src/router/index.js
@@ -5,6 +5,7 @@ import CustomerDetailView from '../views/CustomerDetailView.vue'
 import PropertiesView from '../views/PropertiesView.vue'
 import PropertyDetailsView from '../views/PropertyDetailsView.vue'
 import FollowUpsView from '../views/FollowUpsView.vue'
+import MessageHistoryView from '../views/MessageHistoryView.vue'
 import LoginView from '../views/LoginView.vue'
 import { getSession } from '../services/authService'
 
@@ -50,6 +51,12 @@ const router = createRouter({
       path: '/follow-ups',
       name: 'follow-ups',
       component: FollowUpsView,
+      meta: { requiresAuth: true },
+    },
+    {
+      path: '/messages',
+      name: 'messages',
+      component: MessageHistoryView,
       meta: { requiresAuth: true },
     },
   ],

--- a/Bold_Vision_CRM/src/services/customersService.js
+++ b/Bold_Vision_CRM/src/services/customersService.js
@@ -12,6 +12,8 @@ function mapRowToCustomer(row) {
     createdAt: row.created_at,
     lastContactedAt: row.last_contacted_at ?? null,
     nextContactAt: row.next_contact_at ?? null,
+    telegramChatId: row.telegram_chat_id ?? null,
+    telegramEnrollmentToken: row.telegram_enrollment_token ?? null,
   }
 }
 

--- a/Bold_Vision_CRM/src/services/messagesService.js
+++ b/Bold_Vision_CRM/src/services/messagesService.js
@@ -1,0 +1,99 @@
+import { supabase } from './supabase'
+
+export async function createBroadcast({ propertyId, body, audienceFilter, customers }) {
+  const recipientCustomers = customers.filter((c) => c.telegramChatId)
+
+  // 1. Create the message record
+  const { data: message, error: msgError } = await supabase
+    .from('messages')
+    .insert({
+      property_id: propertyId || null,
+      body,
+      channel: 'Telegram',
+      audience_filter: audienceFilter,
+      recipient_count: recipientCustomers.length,
+    })
+    .select()
+    .single()
+
+  if (msgError) throw msgError
+
+  if (recipientCustomers.length === 0) {
+    return { ok: true, sent: 0, failed: 0, results: [] }
+  }
+
+  // 2. Create queued recipient rows
+  const { data: recipients, error: recipError } = await supabase
+    .from('message_recipients')
+    .insert(
+      recipientCustomers.map((c) => ({
+        message_id: message.id,
+        customer_id: c.id,
+        telegram_chat_id: c.telegramChatId,
+        status: 'queued',
+      }))
+    )
+    .select()
+
+  if (recipError) throw recipError
+
+  // 3. Invoke edge function — sends messages and updates statuses
+  const { data: result, error: fnError } = await supabase.functions.invoke('send-telegram', {
+    body: {
+      messageId: message.id,
+      recipients: recipients.map((r) => ({
+        recipientId: r.id,
+        customerId: r.customer_id,
+        telegramChatId: r.telegram_chat_id,
+        body,
+      })),
+    },
+  })
+
+  if (fnError) throw fnError
+
+  const sent   = result.results?.filter((r) => r.status === 'sent').length  ?? 0
+  const failed = result.results?.filter((r) => r.status === 'failed').length ?? 0
+
+  return { ok: true, sent, failed, results: result.results ?? [] }
+}
+
+export async function listBroadcastsForProperty(propertyId) {
+  const { data, error } = await supabase
+    .from('messages')
+    .select('id, body, audience_filter, recipient_count, sent_at, message_recipients(id, status)')
+    .eq('property_id', propertyId)
+    .order('sent_at', { ascending: false })
+    .limit(5)
+
+  if (error) throw error
+  return data.map(mapMessage)
+}
+
+export async function listAllBroadcasts() {
+  const { data, error } = await supabase
+    .from('messages')
+    .select('id, body, channel, audience_filter, recipient_count, sent_at, property_id, properties(address, suburb)')
+    .order('sent_at', { ascending: false })
+
+  if (error) throw error
+  return data.map(mapMessage)
+}
+
+function mapMessage(row) {
+  const recipients = row.message_recipients ?? []
+  return {
+    id: row.id,
+    body: row.body,
+    channel: row.channel,
+    audienceFilter: row.audience_filter ?? 'All',
+    recipientCount: row.recipient_count,
+    sentAt: row.sent_at,
+    propertyId: row.property_id,
+    propertyAddress: row.properties
+      ? `${row.properties.address}${row.properties.suburb ? ', ' + row.properties.suburb : ''}`
+      : null,
+    sentCount:   recipients.filter((r) => r.status === 'sent').length,
+    failedCount: recipients.filter((r) => r.status === 'failed').length,
+  }
+}

--- a/Bold_Vision_CRM/src/views/CustomerDetailView.vue
+++ b/Bold_Vision_CRM/src/views/CustomerDetailView.vue
@@ -190,6 +190,34 @@
             </v-btn>
           </v-card-actions>
         </v-card>
+
+        <!-- Telegram enrollment -->
+        <v-card elevation="2">
+          <v-card-title class="d-flex align-center">
+            <v-icon class="mr-2" color="primary">mdi-send</v-icon>
+            Telegram
+          </v-card-title>
+          <v-card-text>
+            <template v-if="editable.telegramChatId">
+              <v-alert type="success" variant="tonal" density="compact" icon="mdi-check-circle">
+                Enrolled — this customer will receive Telegram broadcasts.
+              </v-alert>
+            </template>
+            <template v-else>
+              <v-alert type="info" variant="tonal" density="compact" class="mb-3">
+                Not enrolled. Share the instruction below with this customer.
+              </v-alert>
+              <p class="text-caption text-medium-emphasis mb-1">Ask them to send this message to <strong>@BoldVisionPropertiesBot</strong>:</p>
+              <v-card variant="tonal" class="pa-3 mb-3 d-flex align-center justify-space-between">
+                <code class="text-body-2">/start {{ editable.telegramEnrollmentToken }}</code>
+                <v-btn size="x-small" variant="text" icon="mdi-content-copy" @click="copyEnrollment" />
+              </v-card>
+              <p class="text-caption text-medium-emphasis">
+                Once they send it, their Telegram will be linked automatically.
+              </p>
+            </template>
+          </v-card-text>
+        </v-card>
       </v-col>
     </v-row>
 
@@ -243,11 +271,13 @@ const editable = ref({
   notes: '',
   lastContactedAt: null,
   nextContactAt: null,
+  telegramChatId: null,
+  telegramEnrollmentToken: null,
 })
 
-if (original.value) {
-  editable.value = { ...editable.value, ...original.value }
-}
+watch(original, (val) => {
+  if (val) editable.value = { ...editable.value, ...val }
+}, { immediate: true })
 
 // ── Derived / display ───────────────────────────────────────────────────────
 
@@ -393,6 +423,13 @@ async function addFeedback() {
   if (!note || !customerFound.value) return
   await store.addFeedback(id, note)
   newFeedback.value = ''
+}
+
+// ── Telegram enrollment ──────────────────────────────────────────────────────
+
+function copyEnrollment() {
+  const text = `/start ${editable.value.telegramEnrollmentToken}`
+  navigator.clipboard.writeText(text)
 }
 
 // ── Basic info save/reset ────────────────────────────────────────────────────

--- a/Bold_Vision_CRM/src/views/MessageHistoryView.vue
+++ b/Bold_Vision_CRM/src/views/MessageHistoryView.vue
@@ -1,0 +1,83 @@
+<template>
+  <div class="messages">
+    <div class="mb-6">
+      <h2 class="text-h5 font-weight-bold">Broadcast history</h2>
+      <p class="text-body-2 text-medium-emphasis mt-1">All Telegram broadcasts sent from this account.</p>
+    </div>
+
+    <v-card elevation="4">
+      <v-card-text v-if="loading" class="text-center py-8">
+        <v-progress-circular indeterminate color="primary" />
+      </v-card-text>
+
+      <v-card-text v-else-if="!broadcasts.length" class="text-center py-8 text-medium-emphasis">
+        No broadcasts sent yet.
+      </v-card-text>
+
+      <template v-else>
+        <div v-for="b in broadcasts" :key="b.id" class="broadcast-row">
+          <div class="d-flex align-center justify-space-between flex-wrap gap-2 mb-1">
+            <div>
+              <span class="text-body-2 font-weight-medium">{{ formatDate(b.sentAt) }}</span>
+              <v-chip size="x-small" class="ml-2" variant="outlined">{{ b.audienceFilter }}</v-chip>
+              <span v-if="b.propertyAddress" class="text-caption text-medium-emphasis ml-2">
+                {{ b.propertyAddress }}
+              </span>
+            </div>
+            <div class="d-flex gap-2">
+              <v-chip size="x-small" color="success" variant="tonal">
+                {{ b.sentCount }} sent
+              </v-chip>
+              <v-chip v-if="b.failedCount" size="x-small" color="error" variant="tonal">
+                {{ b.failedCount }} failed
+              </v-chip>
+              <v-chip size="x-small" color="primary" variant="tonal">
+                {{ b.recipientCount }} total
+              </v-chip>
+            </div>
+          </div>
+          <p class="text-body-2 text-medium-emphasis message-body">{{ b.body }}</p>
+          <v-divider class="mt-3" />
+        </div>
+      </template>
+    </v-card>
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue'
+import { listAllBroadcasts } from '../services/messagesService'
+
+const broadcasts = ref([])
+const loading    = ref(true)
+
+function formatDate(iso) {
+  return new Date(iso).toLocaleString('en-AU', {
+    day: 'numeric', month: 'short', year: 'numeric',
+    hour: '2-digit', minute: '2-digit', hour12: true,
+  })
+}
+
+onMounted(async () => {
+  try {
+    broadcasts.value = await listAllBroadcasts()
+  } finally {
+    loading.value = false
+  }
+})
+</script>
+
+<style scoped>
+.broadcast-row {
+  padding: 16px 20px;
+}
+
+.message-body {
+  white-space: pre-wrap;
+  max-height: 80px;
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+}
+</style>

--- a/Bold_Vision_CRM/src/views/PropertyDetailsView.vue
+++ b/Bold_Vision_CRM/src/views/PropertyDetailsView.vue
@@ -108,6 +108,9 @@
 
     <!-- Interested customers (full-width Kanban) -->
     <PropertyInterestsPanel :property-id="id" class="mt-2" />
+
+    <!-- Broadcast -->
+    <BroadcastPanel v-if="original" :property="original" class="mt-4" />
   </div>
 
   <div v-else>
@@ -125,6 +128,7 @@ import { createEmptyPropertyDraft } from '../constants/propertyDefaults'
 import PropertyForm from '../components/properties/PropertiesForm.vue'
 import PhotoUploader from '../components/base/PhotoUploader.vue'
 import PropertyInterestsPanel from '../components/properties/PropertyInterestsPanel.vue'
+import BroadcastPanel from '../components/properties/BroadcastPanel.vue'
 
 const route = useRoute()
 const router = useRouter()

--- a/supabase/functions/send-telegram/index.ts
+++ b/supabase/functions/send-telegram/index.ts
@@ -1,0 +1,70 @@
+import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
+
+const TELEGRAM_API = `https://api.telegram.org/bot${Deno.env.get('TELEGRAM_BOT_TOKEN')}`
+const SUPABASE_URL = Deno.env.get('SUPABASE_URL')!
+const SERVICE_KEY  = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+}
+
+serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response(null, { headers: corsHeaders })
+  }
+
+  try {
+    const { messageId, recipients } = await req.json() as {
+      messageId: string
+      recipients: { recipientId: string; customerId: string; telegramChatId: string; body: string }[]
+    }
+
+    const supabase = createClient(SUPABASE_URL, SERVICE_KEY)
+
+    const results = await Promise.all(
+      recipients.map(async (r) => {
+        try {
+          const res = await fetch(`${TELEGRAM_API}/sendMessage`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ chat_id: r.telegramChatId, text: r.body }),
+          })
+          const data = await res.json()
+
+          if (data.ok) {
+            await supabase.from('message_recipients').update({
+              status: 'sent',
+              sent_at: new Date().toISOString(),
+            }).eq('id', r.recipientId)
+            return { customerId: r.customerId, status: 'sent' }
+          } else {
+            await supabase.from('message_recipients').update({
+              status: 'failed',
+              error: data.description ?? 'Unknown error',
+            }).eq('id', r.recipientId)
+            return { customerId: r.customerId, status: 'failed', error: data.description }
+          }
+        } catch (e) {
+          const msg = e instanceof Error ? e.message : String(e)
+          await supabase.from('message_recipients').update({
+            status: 'failed',
+            error: msg,
+          }).eq('id', r.recipientId)
+          return { customerId: r.customerId, status: 'failed', error: msg }
+        }
+      })
+    )
+
+    return new Response(JSON.stringify({ ok: true, results }), {
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    })
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e)
+    return new Response(JSON.stringify({ ok: false, error: msg }), {
+      status: 500,
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    })
+  }
+})

--- a/supabase/functions/telegram-webhook/index.ts
+++ b/supabase/functions/telegram-webhook/index.ts
@@ -1,0 +1,69 @@
+import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
+
+const BOT_TOKEN   = Deno.env.get('TELEGRAM_BOT_TOKEN')!
+const SUPABASE_URL = Deno.env.get('SUPABASE_URL')!
+const SERVICE_KEY  = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!
+
+async function sendMessage(chatId: number, text: string) {
+  await fetch(`https://api.telegram.org/bot${BOT_TOKEN}/sendMessage`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ chat_id: chatId, text }),
+  })
+}
+
+serve(async (req) => {
+  // Telegram sends POST; anything else is a misconfiguration check
+  if (req.method !== 'POST') {
+    return new Response('ok')
+  }
+
+  try {
+    const update = await req.json()
+    const message = update?.message
+    if (!message?.text) return new Response('ok')
+
+    const chatId: number = message.chat.id
+    const text: string   = message.text.trim()
+
+    if (!text.startsWith('/start')) return new Response('ok')
+
+    const token = text.split(' ')[1]?.trim()
+
+    if (!token) {
+      await sendMessage(chatId, 'Welcome to Bold Vision Properties! Contact your agent for an enrollment link.')
+      return new Response('ok')
+    }
+
+    const supabase = createClient(SUPABASE_URL, SERVICE_KEY)
+
+    const { data: customer, error } = await supabase
+      .from('customers')
+      .select('id, name, telegram_chat_id')
+      .eq('telegram_enrollment_token', token)
+      .single()
+
+    if (error || !customer) {
+      await sendMessage(chatId, 'Invalid enrollment code. Please ask your agent for a new link.')
+      return new Response('ok')
+    }
+
+    if (customer.telegram_chat_id) {
+      await sendMessage(chatId, `You're already enrolled, ${customer.name}! You'll receive property updates here.`)
+      return new Response('ok')
+    }
+
+    await supabase
+      .from('customers')
+      .update({ telegram_chat_id: String(chatId) })
+      .eq('id', customer.id)
+
+    await sendMessage(chatId, `You're now enrolled, ${customer.name}! You'll receive property updates from Bold Vision Properties here.`)
+
+    return new Response('ok')
+  } catch (e) {
+    console.error('telegram-webhook error:', e)
+    return new Response('ok') // always 200 to Telegram to prevent retries
+  }
+})

--- a/supabase/migrations/0005_messaging.sql
+++ b/supabase/migrations/0005_messaging.sql
@@ -1,0 +1,83 @@
+-- ─────────────────────────────────────────────────────────────────────────────
+-- Phase 6: messaging tables + Telegram enrollment token
+-- ─────────────────────────────────────────────────────────────────────────────
+
+-- Add Telegram fields to customers
+alter table public.customers
+  add column if not exists telegram_chat_id          text,
+  add column if not exists telegram_enrollment_token text;
+
+-- Backfill enrollment tokens for existing customers (12-char hex)
+update public.customers
+set telegram_enrollment_token = encode(gen_random_bytes(6), 'hex')
+where telegram_enrollment_token is null;
+
+-- Ensure new customers always get a token automatically
+alter table public.customers
+  alter column telegram_enrollment_token set default encode(gen_random_bytes(6), 'hex');
+
+-- ── messages ──────────────────────────────────────────────────────────────────
+create table if not exists public.messages (
+  id               uuid        primary key default gen_random_uuid(),
+  auth_user_id     uuid        not null,
+  property_id      uuid        references public.properties(id) on delete set null,
+  body             text        not null,
+  channel          text        not null default 'Telegram',
+  audience_filter  text,       -- 'All' | 'Hot' | 'Warm' | 'Cold'
+  recipient_count  int         not null default 0,
+  sent_at          timestamptz not null default now(),
+  created_at       timestamptz not null default now()
+);
+
+create or replace function public.set_messages_auth_user_id()
+returns trigger language plpgsql security definer as $$
+begin
+  new.auth_user_id = auth.uid();
+  return new;
+end;
+$$;
+
+create trigger set_messages_auth_user_id
+  before insert on public.messages
+  for each row execute function public.set_messages_auth_user_id();
+
+-- ── message_recipients ────────────────────────────────────────────────────────
+create table if not exists public.message_recipients (
+  id               uuid        primary key default gen_random_uuid(),
+  message_id       uuid        not null references public.messages(id) on delete cascade,
+  customer_id      uuid        not null references public.customers(id) on delete cascade,
+  telegram_chat_id text,
+  status           text        not null default 'queued'
+                               check (status in ('queued', 'sent', 'failed')),
+  error            text,
+  sent_at          timestamptz,
+  created_at       timestamptz not null default now()
+);
+
+-- ── RLS ───────────────────────────────────────────────────────────────────────
+alter table public.messages           enable row level security;
+alter table public.message_recipients enable row level security;
+
+create policy "agent owns messages"
+  on public.messages for all
+  using  (auth.uid() = auth_user_id)
+  with check (auth.uid() = auth_user_id);
+
+create policy "agent owns message_recipients"
+  on public.message_recipients for all
+  using  (exists (
+    select 1 from public.messages m
+    where m.id = message_id and m.auth_user_id = auth.uid()
+  ))
+  with check (exists (
+    select 1 from public.messages m
+    where m.id = message_id and m.auth_user_id = auth.uid()
+  ));
+
+-- ── grants ────────────────────────────────────────────────────────────────────
+grant select, insert, update, delete on public.messages           to authenticated;
+grant select, insert, update, delete on public.message_recipients to authenticated;
+
+-- Edge functions run as service_role; auto-grant is disabled on this project
+grant select, update on public.customers          to service_role;
+grant select, update on public.message_recipients to service_role;


### PR DESCRIPTION
- Add telegram_chat_id and telegram_enrollment_token to customers (migration 0005)
- Webhook edge function handles /start enrollment via bot token
- send-telegram edge function broadcasts property summaries per audience filter
- BroadcastPanel on PropertyDetailsView: audience chips, confirm dialog, recent history
- MessageHistoryView lists all broadcasts across all properties
- CustomerDetailView: Telegram enrollment card + copy button
- Hard-refresh fix: watch(original) re-initialises editable after store loads
- CORS fix: deploy send-telegram with --no-verify-jwt
- Grant service_role SELECT/UPDATE on customers and message_recipients
- Fix Vue fragment warning on BroadcastPanel (inheritAttrs: false + v-bind="$attrs")