### PR TITLE
Feature/phase8 input validation

### DIFF
--- a/Bold_Vision_CRM/src/App.vue
+++ b/Bold_Vision_CRM/src/App.vue
@@ -155,6 +155,9 @@
         <router-view />
       </v-main>
     </template>
+
+    <!-- Global toast — driven by useFeedback() composable -->
+    <AppSnackbar />
   </v-app>
 </template>
 
@@ -167,6 +170,7 @@ import { useCustomerStore } from './stores/customerStore'
 import { useTheme } from './composables/useTheme'
 import { isOverdue } from './utils/followUp'
 import AppIcon from './components/base/AppIcon.vue'
+import AppSnackbar from './components/base/AppSnackbar.vue'
 
 const route = useRoute()
 const router = useRouter()

--- a/Bold_Vision_CRM/src/components/assessment/AssetsSection.vue
+++ b/Bold_Vision_CRM/src/components/assessment/AssetsSection.vue
@@ -11,11 +11,18 @@
     <div class="afm-assets">
       <div v-for="row in ASSET_ROWS" :key="row.key" class="afm-asset">
         <span class="lbl">{{ row.label }}</span>
-        <div class="input-affix">
-          <span class="prefix">$</span>
-          <input class="input has-prefix" type="text" placeholder="0"
-                 :value="modelValue[row.key]"
-                 @input="patch(row.key, $event.target.value)" />
+        <div :class="['afm-field-with-na', { 'afm-na-on': !!na[row.key] }]">
+          <div class="input-affix">
+            <span class="prefix">$</span>
+            <input class="input has-prefix" type="text"
+                   :placeholder="na[row.key] ? 'N/A' : '0'"
+                   inputmode="decimal"
+                   maxlength="15"
+                   :value="modelValue[row.key]"
+                   @keydown="currencyKeydown"
+                   @input="patch(row.key, currencySanitize($event.target.value))" />
+          </div>
+          <NAButton :active="!!na[row.key]" @toggle="toggleNA(row.key)" />
         </div>
       </div>
     </div>
@@ -29,6 +36,8 @@
 
 <script setup>
 import { computed } from 'vue'
+import NAButton from './NAButton.vue'
+import { currencyKeydown, currencySanitize } from '../../utils/inputFilters'
 
 const ASSET_ROWS = [
   { key: 'principalResidence',  label: 'Principal residence' },
@@ -56,6 +65,20 @@ const emit = defineEmits(['update:modelValue'])
 
 function patch(key, value) {
   emit('update:modelValue', { ...props.modelValue, [key]: value })
+}
+
+const na = computed(() => props.modelValue?.na ?? {})
+
+function toggleNA(key) {
+  const naMap = { ...(props.modelValue?.na ?? {}) }
+  const nextActive = !naMap[key]
+  if (nextActive) naMap[key] = true
+  else delete naMap[key]
+  emit('update:modelValue', {
+    ...props.modelValue,
+    [key]: nextActive ? '' : props.modelValue?.[key],
+    na: naMap,
+  })
 }
 
 function parseNum(v) {

--- a/Bold_Vision_CRM/src/components/assessment/DiscoverySection.vue
+++ b/Bold_Vision_CRM/src/components/assessment/DiscoverySection.vue
@@ -9,11 +9,11 @@
     </div>
 
     <div class="afm-discovery">
-      <div v-for="q in QUESTIONS" :key="q.key" class="afm-q">
+      <div v-for="q in QUESTIONS" :key="q.key || q.n" class="afm-q">
         <span class="qn">{{ q.n }}</span>
         <div class="body">
           <div class="q">{{ q.label }}</div>
-          <div class="a">
+          <div :class="['a', 'afm-field-with-na', { 'afm-na-on': isQNA(q) }]">
             <!-- Yes / No -->
             <div v-if="q.kind === 'yesno'" class="seg-control">
               <button type="button"
@@ -37,23 +37,57 @@
               <div class="input-affix">
                 <span class="prefix">$</span>
                 <input class="input has-prefix" type="text" placeholder="Min"
+                       inputmode="decimal"
+                       :maxlength="q.max"
                        :value="getValue(q.minKey)"
-                       @input="setValue(q.minKey, $event.target.value)" />
+                       @keydown="currencyKeydown"
+                       @input="setValue(q.minKey, currencySanitize($event.target.value))" />
               </div>
               <span class="dash">–</span>
               <div class="input-affix">
                 <span class="prefix">$</span>
                 <input class="input has-prefix" type="text" placeholder="Max"
+                       inputmode="decimal"
+                       :maxlength="q.max"
                        :value="getValue(q.maxKey)"
-                       @input="setValue(q.maxKey, $event.target.value)" />
+                       @keydown="currencyKeydown"
+                       @input="setValue(q.maxKey, currencySanitize($event.target.value))" />
               </div>
             </div>
+
+            <!-- Currency single -->
+            <div v-else-if="q.kind === 'currency'" class="input-affix">
+              <span class="prefix">$</span>
+              <input class="input has-prefix" type="text"
+                     :placeholder="q.placeholder"
+                     inputmode="decimal"
+                     :maxlength="q.max"
+                     :value="getValue(q.key)"
+                     @keydown="currencyKeydown"
+                     @input="setValue(q.key, currencySanitize($event.target.value))" />
+            </div>
+
+            <!-- Integer -->
+            <input v-else-if="q.kind === 'int'"
+                   class="input" type="number"
+                   :placeholder="q.placeholder"
+                   min="0" :max="q.maxInt" step="1"
+                   :value="getValue(q.key)"
+                   @keydown="integerKeydown"
+                   @input="setValue(q.key, integerSanitize($event.target.value))" />
+
+            <!-- Month/year picker (stores "YYYY-MM") -->
+            <input v-else-if="q.kind === 'month'"
+                   class="input afm-q-month" type="month"
+                   :value="getValue(q.key)"
+                   @input="setValue(q.key, $event.target.value)" />
 
             <!-- Multi-line text -->
             <textarea v-else-if="q.kind === 'textarea'"
                       class="textarea"
                       :placeholder="q.placeholder"
                       style="min-height:70px"
+                      :maxlength="q.max"
                       :value="getValue(q.key)"
                       @input="setValue(q.key, $event.target.value)"></textarea>
 
@@ -65,14 +99,20 @@
               </span>
               <input class="input has-prefix" type="text"
                      :placeholder="q.placeholder"
+                     :maxlength="q.max"
                      :value="getValue(q.key)"
                      @input="setValue(q.key, $event.target.value)" />
             </div>
             <input v-else
                    class="input" type="text"
                    :placeholder="q.placeholder"
+                   :maxlength="q.max"
                    :value="getValue(q.key)"
                    @input="setValue(q.key, $event.target.value)" />
+
+            <NAButton v-if="q.naEligible !== false"
+                      :active="isQNA(q)"
+                      @toggle="toggleQNA(q)" />
           </div>
         </div>
       </div>
@@ -82,39 +122,45 @@
 
 <script setup>
 import AppIcon from '../base/AppIcon.vue'
+import NAButton from './NAButton.vue'
+import { currencyKeydown, currencySanitize, integerKeydown, integerSanitize } from '../../utils/inputFilters'
 
+// `naEligible: false` on q1/q3/q5/q12 (required questions) hides the N/A
+// button — the agent must answer. Range question (q7) shares one toggle
+// that flips both min + max simultaneously via `naKeys`.
 const QUESTIONS = [
-  { n: 1,  key: 'q1_contactedBroker',     kind: 'yesno',
+  { n: 1,  key: 'q1_contactedBroker',     kind: 'yesno', naEligible: false,
     label: 'Have you contacted with a broker or home loan specialist yet?' },
-  { n: 2,  key: 'q2_lookingDuration',     kind: 'text',
+  { n: 2,  key: 'q2_lookingDuration',     kind: 'text', max: 200,
     label: 'How long have you been looking for buying a property?', placeholder: 'e.g. 3 months' },
-  { n: 3,  key: 'q3_buyTimeline',         kind: 'text',
+  { n: 3,  key: 'q3_buyTimeline',         kind: 'text', max: 200, naEligible: false,
     label: 'When do you want to buy a property?', placeholder: 'e.g. within 3 months' },
   { n: 4,  key: 'q4_talkedBuildersAgents', kind: 'yesno',
     label: 'Have you talked with any builders or real-estate agents?' },
-  { n: 5,  key: 'q5_purpose',             kind: 'seg', options: ['Owner Occ', 'Investment'],
+  { n: 5,  key: 'q5_purpose',             kind: 'seg', options: ['Owner Occ', 'Investment'], naEligible: false,
     label: "What's the purpose of your purchase?" },
-  { n: 6,  key: 'q6_areaOfInterest',      kind: 'text', prefix: 'pin',
+  { n: 6,  key: 'q6_areaOfInterest',      kind: 'text', prefix: 'pin', max: 200,
     label: 'Which area are you looking for?', placeholder: 'Suburbs of interest' },
-  { n: 7,  kind: 'range', minKey: 'q7_budgetMin', maxKey: 'q7_budgetMax',
+  { n: 7,  kind: 'range', minKey: 'q7_budgetMin', maxKey: 'q7_budgetMax', max: 15,
+    naKeys: ['q7_budgetMin', 'q7_budgetMax'],
     label: "What's your budget?" },
-  { n: 8,  key: 'q8_propertyType',        kind: 'text',
+  { n: 8,  key: 'q8_propertyType',        kind: 'text', max: 100,
     label: 'What type of property are you looking for?', placeholder: 'House, townhouse, apartment…' },
-  { n: 9,  key: 'q8b_minBedrooms',        kind: 'text',
+  { n: 9,  key: 'q8b_minBedrooms',        kind: 'int',  maxInt: 50,
     label: 'Minimum bedrooms?', placeholder: 'e.g. 3' },
-  { n: 10, key: 'q9_requirements',        kind: 'textarea',
+  { n: 10, key: 'q9_requirements',        kind: 'textarea', max: 1000,
     label: 'What are your requirements for the property?',
     placeholder: 'Layout, features, school zone, etc.' },
-  { n: 11, key: 'q10_landSize',           kind: 'text',
+  { n: 11, key: 'q10_landSize',           kind: 'text', max: 100,
     label: 'What land size do you need?', placeholder: 'e.g. 400m²+' },
-  { n: 12, key: 'q11_landTitledDate',     kind: 'text',
-    label: 'Date for the land to be titled', placeholder: 'MM/YYYY' },
-  { n: 13, key: 'q12_mostImportant',      kind: 'seg', options: ['Property', 'Location', 'Price'],
+  { n: 12, key: 'q11_landTitledDate',     kind: 'month',
+    label: 'Date for the land to be titled' },
+  { n: 13, key: 'q12_mostImportant',      kind: 'seg', options: ['Property', 'Location', 'Price'], naEligible: false,
     label: "What's most important to you?" },
-  { n: 14, key: 'q13_biggestConcern',     kind: 'textarea',
+  { n: 14, key: 'q13_biggestConcern',     kind: 'textarea', max: 1000,
     label: "What's your biggest concern when buying a property?",
     placeholder: 'Their worries — finance, deposit, area, etc.' },
-  { n: 15, key: 'q14_depositAmount',      kind: 'text', prefix: '$',
+  { n: 15, key: 'q14_depositAmount',      kind: 'currency', max: 15,
     label: 'How much deposit do you have?', placeholder: '0' },
 ]
 
@@ -130,6 +176,32 @@ function getValue(key) {
 function setValue(key, value) {
   emit('update:modelValue', { ...props.modelValue, [key]: value })
 }
+
+// Per-question N/A. Reads `na[primaryKey(q)]` and applies to all keys in
+// `q.naKeys` (defaults to [q.key]) so the range question (q7) toggles both
+// min + max in one click.
+function naKeysFor(q) {
+  return q.naKeys ?? [q.key]
+}
+function primaryNAKey(q) {
+  return naKeysFor(q)[0]
+}
+function isQNA(q) {
+  return props.modelValue?.na?.[primaryNAKey(q)] === true
+}
+function toggleQNA(q) {
+  const na = { ...(props.modelValue?.na ?? {}) }
+  const keys = naKeysFor(q)
+  const nextActive = !na[primaryNAKey(q)]
+  const next = { ...props.modelValue }
+  if (nextActive) {
+    for (const k of keys) { na[k] = true; next[k] = '' }
+  } else {
+    for (const k of keys) delete na[k]
+  }
+  next.na = na
+  emit('update:modelValue', next)
+}
 </script>
 
 <style scoped>
@@ -142,5 +214,9 @@ function setValue(key, value) {
 .afm-q-range .dash {
   font-size: 13px;
   color: var(--text-faint);
+}
+.afm-q-month {
+  /* native month picker tends to stretch — keep it compact like other answers */
+  max-width: 220px;
 }
 </style>

--- a/Bold_Vision_CRM/src/components/assessment/EmploymentSection.vue
+++ b/Bold_Vision_CRM/src/components/assessment/EmploymentSection.vue
@@ -23,21 +23,41 @@
 
       <!-- Occupation -->
       <div class="row-label">Occupation</div>
-      <input v-if="showC1" class="input" type="text" placeholder="e.g. Software engineer"
-             :value="c1.occupation"
-             @input="patch('client1', { occupation: $event.target.value })" />
-      <input v-if="showC2" class="input" type="text" placeholder="Occupation"
-             :value="c2.occupation"
-             @input="patch('client2', { occupation: $event.target.value })" />
+      <div v-if="showC1" :class="['afm-field-with-na', { 'afm-na-on': !!c1.na?.occupation }]">
+        <input class="input" type="text"
+               :placeholder="c1.na?.occupation ? 'N/A' : 'e.g. Software engineer'"
+               :maxlength="LIMITS.assessmentText.max"
+               :value="c1.occupation"
+               @input="patch('client1', { occupation: $event.target.value })" />
+        <NAButton :active="!!c1.na?.occupation" @toggle="toggleNA('client1', 'occupation', { occupation: '' })" />
+      </div>
+      <div v-if="showC2" :class="['afm-field-with-na', { 'afm-na-on': !!c2.na?.occupation }]">
+        <input class="input" type="text"
+               :placeholder="c2.na?.occupation ? 'N/A' : 'Occupation'"
+               :maxlength="LIMITS.assessmentText.max"
+               :value="c2.occupation"
+               @input="patch('client2', { occupation: $event.target.value })" />
+        <NAButton :active="!!c2.na?.occupation" @toggle="toggleNA('client2', 'occupation', { occupation: '' })" />
+      </div>
 
       <!-- Employer -->
       <div class="row-label">Employer</div>
-      <input v-if="showC1" class="input" type="text" placeholder="Employer name"
-             :value="c1.employer"
-             @input="patch('client1', { employer: $event.target.value })" />
-      <input v-if="showC2" class="input" type="text" placeholder="Employer name"
-             :value="c2.employer"
-             @input="patch('client2', { employer: $event.target.value })" />
+      <div v-if="showC1" :class="['afm-field-with-na', { 'afm-na-on': !!c1.na?.employer }]">
+        <input class="input" type="text"
+               :placeholder="c1.na?.employer ? 'N/A' : 'Employer name'"
+               :maxlength="LIMITS.assessmentText.max"
+               :value="c1.employer"
+               @input="patch('client1', { employer: $event.target.value })" />
+        <NAButton :active="!!c1.na?.employer" @toggle="toggleNA('client1', 'employer', { employer: '' })" />
+      </div>
+      <div v-if="showC2" :class="['afm-field-with-na', { 'afm-na-on': !!c2.na?.employer }]">
+        <input class="input" type="text"
+               :placeholder="c2.na?.employer ? 'N/A' : 'Employer name'"
+               :maxlength="LIMITS.assessmentText.max"
+               :value="c2.employer"
+               @input="patch('client2', { employer: $event.target.value })" />
+        <NAButton :active="!!c2.na?.employer" @toggle="toggleNA('client2', 'employer', { employer: '' })" />
+      </div>
 
       <!-- Work status -->
       <div class="row-label">Work status</div>
@@ -71,17 +91,27 @@
 
       <!-- Years in role -->
       <div class="row-label">Years in role</div>
-      <div v-if="showC1" class="input-affix afm-years">
-        <input class="input" type="text" placeholder="0"
-               :value="c1.yearsInRole"
-               @input="patch('client1', { yearsInRole: $event.target.value })" />
-        <span class="suffix">yrs</span>
+      <div v-if="showC1" :class="['afm-field-with-na', { 'afm-na-on': !!c1.na?.yearsInRole }]">
+        <div class="input-affix afm-years">
+          <input class="input" type="number"
+                 :placeholder="c1.na?.yearsInRole ? 'N/A' : '0'"
+                 min="0" max="99" step="0.5"
+                 :value="c1.yearsInRole"
+                 @input="patch('client1', { yearsInRole: $event.target.value })" />
+          <span class="suffix">yrs</span>
+        </div>
+        <NAButton :active="!!c1.na?.yearsInRole" @toggle="toggleNA('client1', 'yearsInRole', { yearsInRole: '' })" />
       </div>
-      <div v-if="showC2" class="input-affix afm-years">
-        <input class="input" type="text" placeholder="0"
-               :value="c2.yearsInRole"
-               @input="patch('client2', { yearsInRole: $event.target.value })" />
-        <span class="suffix">yrs</span>
+      <div v-if="showC2" :class="['afm-field-with-na', { 'afm-na-on': !!c2.na?.yearsInRole }]">
+        <div class="input-affix afm-years">
+          <input class="input" type="number"
+                 :placeholder="c2.na?.yearsInRole ? 'N/A' : '0'"
+                 min="0" max="99" step="0.5"
+                 :value="c2.yearsInRole"
+                 @input="patch('client2', { yearsInRole: $event.target.value })" />
+          <span class="suffix">yrs</span>
+        </div>
+        <NAButton :active="!!c2.na?.yearsInRole" @toggle="toggleNA('client2', 'yearsInRole', { yearsInRole: '' })" />
       </div>
 
       <!-- Probation -->
@@ -105,19 +135,31 @@
 
       <!-- Previous job (if < 1 yr) -->
       <div class="row-label">Previous job (if &lt; 1 yr)</div>
-      <textarea v-if="showC1" class="textarea" placeholder="Commentary on previous job…" style="min-height:60px"
-                :value="c1.previousJobNote"
-                @input="patch('client1', { previousJobNote: $event.target.value })"></textarea>
-      <textarea v-if="showC2" class="textarea" placeholder="Commentary on previous job…" style="min-height:60px"
-                :value="c2.previousJobNote"
-                @input="patch('client2', { previousJobNote: $event.target.value })"></textarea>
+      <div v-if="showC1" :class="['afm-field-with-na', { 'afm-na-on': !!c1.na?.previousJobNote }]">
+        <textarea class="textarea" style="min-height:60px"
+                  :placeholder="c1.na?.previousJobNote ? 'N/A' : 'Commentary on previous job…'"
+                  :maxlength="LIMITS.assessmentLongText.max"
+                  :value="c1.previousJobNote"
+                  @input="patch('client1', { previousJobNote: $event.target.value })"></textarea>
+        <NAButton :active="!!c1.na?.previousJobNote" @toggle="toggleNA('client1', 'previousJobNote', { previousJobNote: '' })" />
+      </div>
+      <div v-if="showC2" :class="['afm-field-with-na', { 'afm-na-on': !!c2.na?.previousJobNote }]">
+        <textarea class="textarea" style="min-height:60px"
+                  :placeholder="c2.na?.previousJobNote ? 'N/A' : 'Commentary on previous job…'"
+                  :maxlength="LIMITS.assessmentLongText.max"
+                  :value="c2.previousJobNote"
+                  @input="patch('client2', { previousJobNote: $event.target.value })"></textarea>
+        <NAButton :active="!!c2.na?.previousJobNote" @toggle="toggleNA('client2', 'previousJobNote', { previousJobNote: '' })" />
+      </div>
     </div>
   </section>
 </template>
 
 <script setup>
 import { computed } from 'vue'
+import NAButton from './NAButton.vue'
 import { useActiveClient, setActiveClient, useIsPhoneView } from '../../composables/useAssessmentClient'
+import { LIMITS } from '../../utils/validators'
 
 const WORK_STATUS_OPTIONS = [
   { value: 'Employee',     label: 'Employee' },
@@ -148,6 +190,19 @@ function patch(which, fieldPatch) {
   emit('update:modelValue', {
     ...props.modelValue,
     [which]: { ...current, ...fieldPatch },
+  })
+}
+
+function toggleNA(which, fieldKey, cleared) {
+  const current = props.modelValue?.[which] ?? {}
+  const na = { ...(current.na ?? {}) }
+  const nextActive = !na[fieldKey]
+  const nextClient = nextActive
+    ? { ...current, ...cleared, na: { ...na, [fieldKey]: true } }
+    : (() => { const n = { ...na }; delete n[fieldKey]; return { ...current, na: n } })()
+  emit('update:modelValue', {
+    ...props.modelValue,
+    [which]: nextClient,
   })
 }
 </script>

--- a/Bold_Vision_CRM/src/components/assessment/IncomeSection.vue
+++ b/Bold_Vision_CRM/src/components/assessment/IncomeSection.vue
@@ -23,33 +23,57 @@
 
       <template v-for="row in INCOME_ROWS" :key="row.key">
         <div class="row-label">{{ row.label }}</div>
-        <div v-if="showC1" class="afm-income-cell">
-          <div class="input-affix">
-            <span class="prefix">$</span>
-            <input class="input has-prefix" type="text"
-                   :placeholder="row.placeholder"
-                   :value="(c1[row.key] ?? {}).amount"
-                   @input="patch('client1', row.key, { amount: $event.target.value })" />
+        <div v-if="showC1" :class="['afm-field-with-na', { 'afm-na-on': !!c1.na?.[row.key] }]">
+          <div class="afm-income-cell" :class="{ 'afm-income-cell--other': row.key === 'other' }">
+            <div class="input-affix">
+              <span class="prefix">$</span>
+              <input class="input has-prefix" type="text"
+                     :placeholder="c1.na?.[row.key] ? 'N/A' : row.placeholder"
+                     inputmode="decimal"
+                     maxlength="15"
+                     :value="(c1[row.key] ?? {}).amount"
+                     @keydown="currencyKeydown"
+                     @input="patchRow('client1', row.key, { amount: currencySanitize($event.target.value) })" />
+            </div>
+            <select class="select"
+                    :value="(c1[row.key] ?? {}).freq || 'pw'"
+                    @change="patchRow('client1', row.key, { freq: $event.target.value })">
+              <option v-for="f in FREQS" :key="f" :value="f">p/{{ f }}</option>
+            </select>
+            <input v-if="row.key === 'other'"
+                   class="input afm-income-detail" type="text"
+                   :placeholder="c1.na?.other ? 'N/A' : 'What is it? (e.g. freelance design, board fees)'"
+                   maxlength="200"
+                   :value="(c1.other ?? {}).details"
+                   @input="patchRow('client1', 'other', { details: $event.target.value })" />
           </div>
-          <select class="select"
-                  :value="(c1[row.key] ?? {}).freq || 'pw'"
-                  @change="patch('client1', row.key, { freq: $event.target.value })">
-            <option v-for="f in FREQS" :key="f" :value="f">p/{{ f }}</option>
-          </select>
+          <NAButton :active="!!c1.na?.[row.key]" @toggle="toggleNARow('client1', row.key)" />
         </div>
-        <div v-if="showC2" class="afm-income-cell">
-          <div class="input-affix">
-            <span class="prefix">$</span>
-            <input class="input has-prefix" type="text"
-                   :placeholder="row.placeholder"
-                   :value="(c2[row.key] ?? {}).amount"
-                   @input="patch('client2', row.key, { amount: $event.target.value })" />
+        <div v-if="showC2" :class="['afm-field-with-na', { 'afm-na-on': !!c2.na?.[row.key] }]">
+          <div class="afm-income-cell" :class="{ 'afm-income-cell--other': row.key === 'other' }">
+            <div class="input-affix">
+              <span class="prefix">$</span>
+              <input class="input has-prefix" type="text"
+                     :placeholder="c2.na?.[row.key] ? 'N/A' : row.placeholder"
+                     inputmode="decimal"
+                     maxlength="15"
+                     :value="(c2[row.key] ?? {}).amount"
+                     @keydown="currencyKeydown"
+                     @input="patchRow('client2', row.key, { amount: currencySanitize($event.target.value) })" />
+            </div>
+            <select class="select"
+                    :value="(c2[row.key] ?? {}).freq || 'pw'"
+                    @change="patchRow('client2', row.key, { freq: $event.target.value })">
+              <option v-for="f in FREQS" :key="f" :value="f">p/{{ f }}</option>
+            </select>
+            <input v-if="row.key === 'other'"
+                   class="input afm-income-detail" type="text"
+                   :placeholder="c2.na?.other ? 'N/A' : 'What is it? (e.g. freelance design, board fees)'"
+                   maxlength="200"
+                   :value="(c2.other ?? {}).details"
+                   @input="patchRow('client2', 'other', { details: $event.target.value })" />
           </div>
-          <select class="select"
-                  :value="(c2[row.key] ?? {}).freq || 'pw'"
-                  @change="patch('client2', row.key, { freq: $event.target.value })">
-            <option v-for="f in FREQS" :key="f" :value="f">p/{{ f }}</option>
-          </select>
+          <NAButton :active="!!c2.na?.[row.key]" @toggle="toggleNARow('client2', row.key)" />
         </div>
       </template>
     </div>
@@ -58,7 +82,9 @@
 
 <script setup>
 import { computed } from 'vue'
+import NAButton from './NAButton.vue'
 import { useActiveClient, setActiveClient, useIsPhoneView } from '../../composables/useAssessmentClient'
+import { currencyKeydown, currencySanitize } from '../../utils/inputFilters'
 
 const FREQS = ['w', 'f', 'm', 'a']
 const INCOME_ROWS = [
@@ -83,7 +109,7 @@ const activeClient = useActiveClient()
 const showC1 = computed(() => !isPhone.value || activeClient.value === 'client1')
 const showC2 = computed(() => !isPhone.value || activeClient.value === 'client2')
 
-function patch(which, rowKey, partial) {
+function patchRow(which, rowKey, partial) {
   const clientObj = props.modelValue?.[which] ?? {}
   const rowObj = clientObj[rowKey] ?? {}
   emit('update:modelValue', {
@@ -92,6 +118,27 @@ function patch(which, rowKey, partial) {
       ...clientObj,
       [rowKey]: { ...rowObj, ...partial },
     },
+  })
+}
+
+// Toggling N/A on an income row clears the row entirely (amount + freq +
+// details), flips the flag, and persists.
+function toggleNARow(which, rowKey) {
+  const clientObj = props.modelValue?.[which] ?? {}
+  const na = { ...(clientObj.na ?? {}) }
+  const nextActive = !na[rowKey]
+  let nextClient
+  if (nextActive) {
+    na[rowKey] = true
+    // Clear the row's data
+    nextClient = { ...clientObj, [rowKey]: null, na }
+  } else {
+    delete na[rowKey]
+    nextClient = { ...clientObj, na }
+  }
+  emit('update:modelValue', {
+    ...props.modelValue,
+    [which]: nextClient,
   })
 }
 </script>
@@ -104,4 +151,12 @@ function patch(which, rowKey, partial) {
   align-items: center;
 }
 .afm-income-cell .select { width: 100%; padding: 10px 8px; }
+
+/* Other (specify) variant — adds a full-width description below amount + freq */
+.afm-income-cell--other {
+  grid-template-rows: auto auto;
+}
+.afm-income-cell--other .afm-income-detail {
+  grid-column: 1 / span 2;
+}
 </style>

--- a/Bold_Vision_CRM/src/components/assessment/LiabilitiesSection.vue
+++ b/Bold_Vision_CRM/src/components/assessment/LiabilitiesSection.vue
@@ -6,8 +6,13 @@
         <h2>Liabilities</h2>
         <div class="desc">Loans, cards, and other obligations.</div>
       </div>
+      <label :class="['afm-section-na', { 'is-active': naSection }]">
+        <input type="checkbox" :checked="naSection" @change="toggleSectionNA($event.target.checked)" />
+        No liabilities to record
+      </label>
     </div>
 
+    <template v-if="!naSection">
     <div v-if="rows.length === 0" class="afm-liab-empty">
       No liabilities yet. Pick a type below to add one.
     </div>
@@ -28,22 +33,29 @@
           {{ row.type }}
         </div>
         <input class="input" type="text" placeholder="Notes"
+               :maxlength="LIMITS.assessmentText.max"
                :value="row.details"
                @input="updateRow(i, { details: $event.target.value })" />
         <div class="input-affix">
           <span class="prefix">$</span>
           <input class="input has-prefix" type="text" placeholder="0"
+                 inputmode="decimal"
+                 maxlength="15"
                  :value="row.value"
-                 @input="updateRow(i, { value: $event.target.value })" />
+                 @keydown="currencyKeydown"
+                 @input="updateRow(i, { value: currencySanitize($event.target.value) })" />
         </div>
         <input class="input" type="text" placeholder="Lender"
+               :maxlength="LIMITS.assessmentText.max"
                :value="row.lender"
                @input="updateRow(i, { lender: $event.target.value })" />
-        <input class="input" type="text" placeholder="0 yrs"
+        <input class="input" type="number" placeholder="0"
+               min="0" max="99" step="1"
                :value="row.remainingTerm"
                @input="updateRow(i, { remainingTerm: $event.target.value })" />
         <div class="input-affix">
-          <input class="input" type="text" placeholder="0"
+          <input class="input" type="number" placeholder="0"
+                 min="0" max="30" step="0.01"
                  :value="row.interestRate"
                  @input="updateRow(i, { interestRate: $event.target.value })" />
           <span class="suffix">%</span>
@@ -51,8 +63,11 @@
         <div class="input-affix">
           <span class="prefix">$</span>
           <input class="input has-prefix" type="text" placeholder="0"
+                 inputmode="decimal"
+                 maxlength="15"
                  :value="row.repayment"
-                 @input="updateRow(i, { repayment: $event.target.value })" />
+                 @keydown="currencyKeydown"
+                 @input="updateRow(i, { repayment: currencySanitize($event.target.value) })" />
         </div>
         <button class="row-del" type="button" aria-label="Remove liability"
                 @click="removeRow(i)">
@@ -63,15 +78,25 @@
 
     <div class="afm-liab-presets">
       <button v-for="t in PRESET_TYPES" :key="t" type="button"
-              class="btn btn-ghost sm" @click="addRow(t)">
+              class="btn btn-ghost sm"
+              :disabled="rowCapReached"
+              @click="addRow(t)">
         <AppIcon name="plus" :size="11" />
         {{ t }}
       </button>
+      <span v-if="rowCapReached" class="afm-liab-cap">
+        Max {{ LIMITS.liabilityRowCap.max }} rows
+      </span>
     </div>
 
     <div class="afm-total-row">
       <span class="lbl">Total debt value</span>
       <span class="val">{{ formattedTotal }}</span>
+    </div>
+    </template>
+
+    <div v-else class="afm-liab-empty">
+      Marked as Not Applicable — no liabilities recorded for this customer.
     </div>
   </section>
 </template>
@@ -79,6 +104,11 @@
 <script setup>
 import { computed } from 'vue'
 import AppIcon from '../base/AppIcon.vue'
+import { LIMITS } from '../../utils/validators'
+import { useFeedback } from '../../composables/useFeedback'
+import { currencyKeydown, currencySanitize } from '../../utils/inputFilters'
+
+const { notifyError } = useFeedback()
 
 const PRESET_TYPES = [
   'Home Loan',
@@ -104,9 +134,22 @@ const props = defineProps({
 const emit = defineEmits(['update:modelValue'])
 
 const rows = computed(() => props.modelValue?.rows ?? [])
+const naSection = computed(() => props.modelValue?.naSection === true)
 
 function emitRows(nextRows) {
   emit('update:modelValue', { ...props.modelValue, rows: nextRows })
+}
+
+// Whole-section N/A: marks the section as having no liabilities to record.
+// Clears the rows array on activate (so we don't keep stale data + flag).
+function toggleSectionNA(checked) {
+  if (checked) {
+    emit('update:modelValue', { ...props.modelValue, rows: [], naSection: true })
+  } else {
+    const next = { ...props.modelValue }
+    delete next.naSection
+    emit('update:modelValue', next)
+  }
 }
 
 function newId() {
@@ -115,7 +158,13 @@ function newId() {
     : 'lia_' + Math.random().toString(36).slice(2, 11)
 }
 
+const rowCapReached = computed(() => rows.value.length >= LIMITS.liabilityRowCap.max)
+
 function addRow(type) {
+  if (rowCapReached.value) {
+    notifyError(`Liabilities capped at ${LIMITS.liabilityRowCap.max} rows`)
+    return
+  }
   const next = [
     ...rows.value,
     { id: newId(), type, details: '', value: '', lender: '',
@@ -179,4 +228,11 @@ const formattedTotal = computed(() =>
   margin-top: 12px;
 }
 .afm-liab-presets .btn { text-decoration: none; }
+.afm-liab-presets .btn:disabled { opacity: 0.45; cursor: not-allowed; }
+.afm-liab-cap {
+  align-self: center;
+  font-size: 11.5px;
+  font-style: italic;
+  color: var(--text-faint);
+}
 </style>

--- a/Bold_Vision_CRM/src/components/assessment/NAButton.vue
+++ b/Bold_Vision_CRM/src/components/assessment/NAButton.vue
@@ -1,0 +1,17 @@
+<template>
+  <button
+    type="button"
+    class="afm-na-btn"
+    :class="{ 'is-active': active }"
+    :aria-pressed="active"
+    :title="active ? 'Marked Not Applicable — click to undo' : 'Mark not applicable'"
+    @click.stop="$emit('toggle')"
+  >N/A</button>
+</template>
+
+<script setup>
+defineProps({
+  active: { type: Boolean, default: false },
+})
+defineEmits(['toggle'])
+</script>

--- a/Bold_Vision_CRM/src/components/assessment/NotesSection.vue
+++ b/Bold_Vision_CRM/src/components/assessment/NotesSection.vue
@@ -15,18 +15,24 @@
           <span class="prefix"><AppIcon name="user" :size="14" /></span>
           <input id="afm-consultant" class="input has-prefix" type="text"
                  placeholder="Consultant name"
+                 :maxlength="LIMITS.assessmentText.max"
                  :value="meta.consultantName"
                  @input="updateMeta({ consultantName: $event.target.value })" />
         </div>
       </div>
       <div class="field">
         <label for="afm-broker">Broker</label>
-        <div class="input-affix">
-          <span class="prefix"><AppIcon name="user" :size="14" /></span>
-          <input id="afm-broker" class="input has-prefix" type="text"
-                 placeholder="Broker name"
-                 :value="meta.brokerName"
-                 @input="updateMeta({ brokerName: $event.target.value })" />
+        <div :class="['afm-field-with-na', { 'afm-na-on': isNA('brokerName') }]">
+          <div class="input-affix">
+            <span class="prefix"><AppIcon name="user" :size="14" /></span>
+            <input id="afm-broker" class="input has-prefix" type="text"
+                   :placeholder="isNA('brokerName') ? 'N/A' : 'Broker name'"
+                   :maxlength="LIMITS.assessmentText.max"
+                   :value="meta.brokerName"
+                   @input="updateMeta({ brokerName: $event.target.value })" />
+          </div>
+          <NAButton :active="isNA('brokerName')"
+                    @toggle="toggleNA('brokerName', { clearMeta: { brokerName: '' } })" />
         </div>
       </div>
     </div>
@@ -35,35 +41,53 @@
       <div class="afm-notes-meta-grid">
         <div class="field">
           <label for="afm-preapproval-amount">Pre-approval amount</label>
-          <div class="input-affix">
-            <span class="prefix">$</span>
-            <input id="afm-preapproval-amount" class="input has-prefix" type="text"
-                   placeholder="0"
-                   :value="notes.preApprovalAmount"
-                   @input="updateNotes({ preApprovalAmount: $event.target.value })" />
+          <div :class="['afm-field-with-na', { 'afm-na-on': isNA('preApprovalAmount') }]">
+            <div class="input-affix">
+              <span class="prefix">$</span>
+              <input id="afm-preapproval-amount" class="input has-prefix" type="text"
+                     :placeholder="isNA('preApprovalAmount') ? 'N/A' : '0'"
+                     inputmode="decimal"
+                     maxlength="15"
+                     :value="notes.preApprovalAmount"
+                     @keydown="currencyKeydown"
+                     @input="updateNotes({ preApprovalAmount: currencySanitize($event.target.value) })" />
+            </div>
+            <NAButton :active="isNA('preApprovalAmount')"
+                      @toggle="toggleNA('preApprovalAmount', { clearNotes: { preApprovalAmount: '' } })" />
           </div>
         </div>
         <div class="field">
           <label for="afm-preapproval-lender">Pre-approval lender</label>
-          <input id="afm-preapproval-lender" class="input" type="text"
-                 placeholder="e.g. Westpac"
-                 :value="notes.preApprovalLender"
-                 @input="updateNotes({ preApprovalLender: $event.target.value })" />
+          <div :class="['afm-field-with-na', { 'afm-na-on': isNA('preApprovalLender') }]">
+            <input id="afm-preapproval-lender" class="input" type="text"
+                   :placeholder="isNA('preApprovalLender') ? 'N/A' : 'e.g. Westpac'"
+                   :maxlength="LIMITS.assessmentText.max"
+                   :value="notes.preApprovalLender"
+                   @input="updateNotes({ preApprovalLender: $event.target.value })" />
+            <NAButton :active="isNA('preApprovalLender')"
+                      @toggle="toggleNA('preApprovalLender', { clearNotes: { preApprovalLender: '' } })" />
+          </div>
         </div>
       </div>
       <div class="field">
         <label for="afm-cnotes">Consultant notes</label>
         <textarea id="afm-cnotes" class="textarea" style="min-height:100px"
                   placeholder="What stood out? Decisions, blockers, follow-ups…"
+                  :maxlength="LIMITS.assessmentNote.max"
                   :value="notes.consultantNotes"
                   @input="updateNotes({ consultantNotes: $event.target.value })"></textarea>
       </div>
       <div class="field">
         <label for="afm-bnotes">Broker notes (borrowing capacity)</label>
-        <textarea id="afm-bnotes" class="textarea" style="min-height:80px"
-                  placeholder="Borrowing capacity estimate, pre-approval status, conditions…"
-                  :value="notes.brokerNotes"
-                  @input="updateNotes({ brokerNotes: $event.target.value })"></textarea>
+        <div :class="['afm-field-with-na', { 'afm-na-on': isNA('brokerNotes') }]">
+          <textarea id="afm-bnotes" class="textarea" style="min-height:80px"
+                    :placeholder="isNA('brokerNotes') ? 'N/A' : 'Borrowing capacity estimate, pre-approval status, conditions…'"
+                    :maxlength="LIMITS.assessmentNote.max"
+                    :value="notes.brokerNotes"
+                    @input="updateNotes({ brokerNotes: $event.target.value })"></textarea>
+          <NAButton :active="isNA('brokerNotes')"
+                    @toggle="toggleNA('brokerNotes', { clearNotes: { brokerNotes: '' } })" />
+        </div>
       </div>
       <div class="afm-notes-meta-grid">
         <div class="field">
@@ -74,9 +98,13 @@
         </div>
         <div class="field">
           <label for="afm-next">Next appointment date</label>
-          <input id="afm-next" class="input" type="datetime-local"
-                 :value="datetimeLocalValue"
-                 @input="updateMeta({ nextAppointmentAt: toIso($event.target.value) })" />
+          <div :class="['afm-field-with-na', { 'afm-na-on': isNA('nextAppointmentAt') }]">
+            <input id="afm-next" class="input" type="datetime-local"
+                   :value="datetimeLocalValue"
+                   @input="updateMeta({ nextAppointmentAt: toIso($event.target.value) })" />
+            <NAButton :active="isNA('nextAppointmentAt')"
+                      @toggle="toggleNA('nextAppointmentAt', { clearMeta: { nextAppointmentAt: null } })" />
+          </div>
         </div>
       </div>
     </div>
@@ -86,6 +114,9 @@
 <script setup>
 import { computed } from 'vue'
 import AppIcon from '../base/AppIcon.vue'
+import NAButton from './NAButton.vue'
+import { LIMITS } from '../../utils/validators'
+import { currencyKeydown, currencySanitize } from '../../utils/inputFilters'
 
 const props = defineProps({
   notes: { type: Object, default: () => ({}) },
@@ -99,6 +130,32 @@ function updateNotes(partial) {
 
 function updateMeta(partial) {
   emit('update:meta', partial)
+}
+
+// N/A flags for all Notes section optional fields live in `notes.na`, even
+// when the underlying value is on a top-level meta column (brokerName,
+// nextAppointmentAt). Toggling clears the value in whichever store owns it
+// AND flips the flag in `notes.na` in a single payload.
+function isNA(key) {
+  return props.notes?.na?.[key] === true
+}
+
+function toggleNA(key, { clearNotes = null, clearMeta = null } = {}) {
+  const na = { ...(props.notes?.na ?? {}) }
+  const nextActive = !na[key]
+  if (nextActive) na[key] = true
+  else delete na[key]
+
+  // Always emit the new notes payload (with na + any clearNotes patches)
+  emit('update:notes', {
+    ...props.notes,
+    ...(nextActive && clearNotes ? clearNotes : {}),
+    na,
+  })
+  // And if the value lives on the meta side, clear it there too on activate
+  if (nextActive && clearMeta) {
+    emit('update:meta', clearMeta)
+  }
 }
 
 // <input type="datetime-local"> needs `YYYY-MM-DDTHH:MM`; we store ISO strings.

--- a/Bold_Vision_CRM/src/components/assessment/PersonalSection.vue
+++ b/Bold_Vision_CRM/src/components/assessment/PersonalSection.vue
@@ -24,25 +24,47 @@
       <!-- Full name -->
       <div class="row-label">Full name</div>
       <input v-if="showC1" class="input" type="text" placeholder="Full name"
+             :maxlength="LIMITS.assessmentText.max"
              :value="c1.fullName"
              @input="patch('client1', { fullName: $event.target.value })" />
       <input v-if="showC2" class="input" type="text" placeholder="Full name"
+             :maxlength="LIMITS.assessmentText.max"
              :value="c2.fullName"
              @input="patch('client2', { fullName: $event.target.value })" />
 
       <!-- DOB · age -->
       <div class="row-label">Date of birth · age</div>
-      <div v-if="showC1" class="input-affix">
-        <span class="prefix"><AppIcon name="calendar" :size="14" /></span>
-        <input class="input has-prefix" type="text" placeholder="DD/MM/YYYY · Age"
-               :value="c1.dob"
-               @input="patch('client1', { dob: $event.target.value })" />
+      <div v-if="showC1" :class="['afm-field-with-na', { 'afm-na-on': !!c1.na?.dobDate }]">
+        <div class="afm-dob-row">
+          <input class="input" type="date"
+                 :max="todayIso"
+                 :value="c1.dobDate"
+                 @input="onDobChange('client1', $event.target.value)" />
+          <div class="input-affix afm-dob-age">
+            <input class="input has-suffix" type="number" placeholder="Age"
+                   min="0" max="120"
+                   :value="c1.age"
+                   @input="patch('client1', { age: clampInt($event.target.value, 0, 120) })" />
+            <span class="suffix">yrs</span>
+          </div>
+        </div>
+        <NAButton :active="!!c1.na?.dobDate" @toggle="toggleNA('client1', 'dobDate', { dobDate: '', age: '', dob: '' })" />
       </div>
-      <div v-if="showC2" class="input-affix">
-        <span class="prefix"><AppIcon name="calendar" :size="14" /></span>
-        <input class="input has-prefix" type="text" placeholder="DD/MM/YYYY · Age"
-               :value="c2.dob"
-               @input="patch('client2', { dob: $event.target.value })" />
+      <div v-if="showC2" :class="['afm-field-with-na', { 'afm-na-on': !!c2.na?.dobDate }]">
+        <div class="afm-dob-row">
+          <input class="input" type="date"
+                 :max="todayIso"
+                 :value="c2.dobDate"
+                 @input="onDobChange('client2', $event.target.value)" />
+          <div class="input-affix afm-dob-age">
+            <input class="input has-suffix" type="number" placeholder="Age"
+                   min="0" max="120"
+                   :value="c2.age"
+                   @input="patch('client2', { age: clampInt($event.target.value, 0, 120) })" />
+            <span class="suffix">yrs</span>
+          </div>
+        </div>
+        <NAButton :active="!!c2.na?.dobDate" @toggle="toggleNA('client2', 'dobDate', { dobDate: '', age: '', dob: '' })" />
       </div>
 
       <!-- Marital status -->
@@ -60,26 +82,52 @@
 
       <!-- Dependants -->
       <div class="row-label">Dependants</div>
-      <input v-if="showC1" class="input" type="text" placeholder="No. &amp; ages (e.g. 2 · 6, 8)"
-             :value="c1.dependants"
-             @input="patch('client1', { dependants: $event.target.value })" />
-      <input v-if="showC2" class="input" type="text" placeholder="No. &amp; ages"
-             :value="c2.dependants"
-             @input="patch('client2', { dependants: $event.target.value })" />
+      <div v-if="showC1" :class="['afm-field-with-na', { 'afm-na-on': !!c1.na?.dependants }]">
+        <input class="input" type="text"
+               :placeholder="c1.na?.dependants ? 'N/A' : 'No. & ages (e.g. 2 · 6, 8)'"
+               :maxlength="LIMITS.assessmentText.max"
+               :value="c1.dependants"
+               @input="patch('client1', { dependants: $event.target.value })" />
+        <NAButton :active="!!c1.na?.dependants" @toggle="toggleNA('client1', 'dependants', { dependants: '' })" />
+      </div>
+      <div v-if="showC2" :class="['afm-field-with-na', { 'afm-na-on': !!c2.na?.dependants }]">
+        <input class="input" type="text"
+               :placeholder="c2.na?.dependants ? 'N/A' : 'No. & ages'"
+               :maxlength="LIMITS.assessmentText.max"
+               :value="c2.dependants"
+               @input="patch('client2', { dependants: $event.target.value })" />
+        <NAButton :active="!!c2.na?.dependants" @toggle="toggleNA('client2', 'dependants', { dependants: '' })" />
+      </div>
 
       <!-- Residency -->
       <div class="row-label">Residency</div>
-      <div v-if="showC1" class="seg-control">
-        <button v-for="opt in RESIDENCY_OPTIONS" :key="opt"
-                type="button"
-                :aria-pressed="(c1.residency || 'Citizen') === opt"
-                @click="patch('client1', { residency: opt })">{{ opt }}</button>
+      <div v-if="showC1" class="afm-residency-cell">
+        <div class="seg-control">
+          <button v-for="opt in RESIDENCY_OPTIONS" :key="opt"
+                  type="button"
+                  :aria-pressed="(c1.residency || 'Citizen') === opt"
+                  @click="patch('client1', { residency: opt })">{{ opt }}</button>
+        </div>
+        <input v-if="c1.residency === 'Other'"
+               class="input afm-residency-other" type="text"
+               placeholder="Specify (e.g. Work visa, 491)"
+               maxlength="100"
+               :value="c1.residencyOther"
+               @input="patch('client1', { residencyOther: $event.target.value })" />
       </div>
-      <div v-if="showC2" class="seg-control">
-        <button v-for="opt in RESIDENCY_OPTIONS" :key="opt"
-                type="button"
-                :aria-pressed="(c2.residency || 'Citizen') === opt"
-                @click="patch('client2', { residency: opt })">{{ opt }}</button>
+      <div v-if="showC2" class="afm-residency-cell">
+        <div class="seg-control">
+          <button v-for="opt in RESIDENCY_OPTIONS" :key="opt"
+                  type="button"
+                  :aria-pressed="(c2.residency || 'Citizen') === opt"
+                  @click="patch('client2', { residency: opt })">{{ opt }}</button>
+        </div>
+        <input v-if="c2.residency === 'Other'"
+               class="input afm-residency-other" type="text"
+               placeholder="Specify (e.g. Work visa, 491)"
+               maxlength="100"
+               :value="c2.residencyOther"
+               @input="patch('client2', { residencyOther: $event.target.value })" />
       </div>
 
       <!-- Phone -->
@@ -87,29 +135,41 @@
       <div v-if="showC1" class="input-affix">
         <span class="prefix"><AppIcon name="phone" :size="14" /></span>
         <input class="input has-prefix" type="tel" placeholder="04xx xxx xxx"
+               :maxlength="LIMITS.phone.max"
                :value="c1.phone"
                @input="patch('client1', { phone: $event.target.value })" />
       </div>
       <div v-if="showC2" class="input-affix">
         <span class="prefix"><AppIcon name="phone" :size="14" /></span>
         <input class="input has-prefix" type="tel" placeholder="04xx xxx xxx"
+               :maxlength="LIMITS.phone.max"
                :value="c2.phone"
                @input="patch('client2', { phone: $event.target.value })" />
       </div>
 
       <!-- Home address -->
       <div class="row-label">Home address</div>
-      <div v-if="showC1" class="input-affix">
-        <span class="prefix"><AppIcon name="pin" :size="14" /></span>
-        <input class="input has-prefix" type="text" placeholder="Street, suburb, state, postcode"
-               :value="c1.address"
-               @input="patch('client1', { address: $event.target.value })" />
+      <div v-if="showC1" :class="['afm-field-with-na', { 'afm-na-on': !!c1.na?.address }]">
+        <div class="input-affix">
+          <span class="prefix"><AppIcon name="pin" :size="14" /></span>
+          <input class="input has-prefix" type="text"
+                 :placeholder="c1.na?.address ? 'N/A' : 'Street, suburb, state, postcode'"
+                 :maxlength="LIMITS.address.max"
+                 :value="c1.address"
+                 @input="patch('client1', { address: $event.target.value })" />
+        </div>
+        <NAButton :active="!!c1.na?.address" @toggle="toggleNA('client1', 'address', { address: '' })" />
       </div>
-      <div v-if="showC2" class="input-affix">
-        <span class="prefix"><AppIcon name="pin" :size="14" /></span>
-        <input class="input has-prefix" type="text" placeholder="Same as Client 1"
-               :value="c2.address"
-               @input="patch('client2', { address: $event.target.value })" />
+      <div v-if="showC2" :class="['afm-field-with-na', { 'afm-na-on': !!c2.na?.address }]">
+        <div class="input-affix">
+          <span class="prefix"><AppIcon name="pin" :size="14" /></span>
+          <input class="input has-prefix" type="text"
+                 :placeholder="c2.na?.address ? 'N/A' : 'Same as Client 1'"
+                 :maxlength="LIMITS.address.max"
+                 :value="c2.address"
+                 @input="patch('client2', { address: $event.target.value })" />
+        </div>
+        <NAButton :active="!!c2.na?.address" @toggle="toggleNA('client2', 'address', { address: '' })" />
       </div>
 
       <!-- Housing status -->
@@ -129,33 +189,47 @@
 
       <!-- Rent -->
       <div class="row-label">Rent</div>
-      <div v-if="showC1" class="afm-rent-row">
-        <div class="input-affix">
-          <span class="prefix">$</span>
-          <input class="input has-prefix" type="text" placeholder="0"
-                 :value="c1.rentAmount"
-                 @input="patch('client1', { rentAmount: $event.target.value })" />
+      <div v-if="showC1" :class="['afm-field-with-na', { 'afm-na-on': !!c1.na?.rentAmount }]">
+        <div class="afm-rent-row">
+          <div class="input-affix">
+            <span class="prefix">$</span>
+            <input class="input has-prefix" type="text"
+                   :placeholder="c1.na?.rentAmount ? 'N/A' : '0'"
+                   inputmode="decimal"
+                   maxlength="15"
+                   :value="c1.rentAmount"
+                   @keydown="currencyKeydown"
+                   @input="patch('client1', { rentAmount: currencySanitize($event.target.value) })" />
+          </div>
+          <div class="seg-control">
+            <button v-for="opt in FREQ_OPTIONS" :key="opt"
+                    type="button"
+                    :aria-pressed="(c1.rentFreq || 'pw') === opt"
+                    @click="patch('client1', { rentFreq: opt })">/{{ opt }}</button>
+          </div>
         </div>
-        <div class="seg-control">
-          <button v-for="opt in FREQ_OPTIONS" :key="opt"
-                  type="button"
-                  :aria-pressed="(c1.rentFreq || 'pw') === opt"
-                  @click="patch('client1', { rentFreq: opt })">/{{ opt }}</button>
-        </div>
+        <NAButton :active="!!c1.na?.rentAmount" @toggle="toggleNA('client1', 'rentAmount', { rentAmount: '' })" />
       </div>
-      <div v-if="showC2" class="afm-rent-row">
-        <div class="input-affix">
-          <span class="prefix">$</span>
-          <input class="input has-prefix" type="text" placeholder="0"
-                 :value="c2.rentAmount"
-                 @input="patch('client2', { rentAmount: $event.target.value })" />
+      <div v-if="showC2" :class="['afm-field-with-na', { 'afm-na-on': !!c2.na?.rentAmount }]">
+        <div class="afm-rent-row">
+          <div class="input-affix">
+            <span class="prefix">$</span>
+            <input class="input has-prefix" type="text"
+                   :placeholder="c2.na?.rentAmount ? 'N/A' : '0'"
+                   inputmode="decimal"
+                   maxlength="15"
+                   :value="c2.rentAmount"
+                   @keydown="currencyKeydown"
+                   @input="patch('client2', { rentAmount: currencySanitize($event.target.value) })" />
+          </div>
+          <div class="seg-control">
+            <button v-for="opt in FREQ_OPTIONS" :key="opt"
+                    type="button"
+                    :aria-pressed="(c2.rentFreq || 'pw') === opt"
+                    @click="patch('client2', { rentFreq: opt })">/{{ opt }}</button>
+          </div>
         </div>
-        <div class="seg-control">
-          <button v-for="opt in FREQ_OPTIONS" :key="opt"
-                  type="button"
-                  :aria-pressed="(c2.rentFreq || 'pw') === opt"
-                  @click="patch('client2', { rentFreq: opt })">/{{ opt }}</button>
-        </div>
+        <NAButton :active="!!c2.na?.rentAmount" @toggle="toggleNA('client2', 'rentAmount', { rentAmount: '' })" />
       </div>
 
       <!-- Purpose of enquiry -->
@@ -193,7 +267,31 @@
 <script setup>
 import { computed } from 'vue'
 import AppIcon from '../base/AppIcon.vue'
+import NAButton from './NAButton.vue'
 import { useActiveClient, setActiveClient, useIsPhoneView } from '../../composables/useAssessmentClient'
+import { LIMITS } from '../../utils/validators'
+import { currencyKeydown, currencySanitize } from '../../utils/inputFilters'
+
+// ISO date for `<input type="date" :max>` — prevents picking a DOB in the future.
+const todayIso = new Date().toISOString().slice(0, 10)
+
+function clampInt(value, min, max) {
+  if (value === '' || value == null) return ''
+  const n = parseInt(value, 10)
+  if (!Number.isFinite(n)) return ''
+  return Math.min(Math.max(n, min), max)
+}
+
+function computeAge(dobIso) {
+  if (!dobIso) return null
+  const dob = new Date(dobIso)
+  if (Number.isNaN(dob.getTime())) return null
+  const now = new Date()
+  let age = now.getFullYear() - dob.getFullYear()
+  const m = now.getMonth() - dob.getMonth()
+  if (m < 0 || (m === 0 && now.getDate() < dob.getDate())) age--
+  return age >= 0 && age <= 150 ? age : null
+}
 
 const MARITAL_OPTIONS = ['Single', 'Married', 'De facto', 'Separated', 'Other']
 const RESIDENCY_OPTIONS = ['Citizen', 'PR', 'Other']
@@ -226,6 +324,32 @@ function patch(which, fieldPatch) {
     [which]: { ...current, ...fieldPatch },
   })
 }
+
+// When the agent picks a date, auto-fill the age field from it. They can still
+// override the age manually afterwards (rare — when DOB is approximate).
+// Also clears the legacy `dob` text field so the JSONB doesn't keep stale
+// "DD/MM/YYYY · Age" strings around alongside the new split fields.
+function onDobChange(which, dobIso) {
+  const age = computeAge(dobIso)
+  patch(which, { dobDate: dobIso || '', age: age ?? '', dob: '' })
+}
+
+// N/A toggle for client-split sections. When activating, also clears the
+// underlying value(s) so the JSONB doesn't carry stale "$1500 + na=true" state.
+// `cleared` lists the field name(s) to reset (most fields are simple — just
+// the same key — but compound rows like DOB clear dobDate+age+dob together).
+function toggleNA(which, fieldKey, cleared) {
+  const current = props.modelValue?.[which] ?? {}
+  const na = { ...(current.na ?? {}) }
+  const nextActive = !na[fieldKey]
+  const nextClient = nextActive
+    ? { ...current, ...cleared, na: { ...na, [fieldKey]: true } }
+    : (() => { const n = { ...na }; delete n[fieldKey]; return { ...current, na: n } })()
+  emit('update:modelValue', {
+    ...props.modelValue,
+    [which]: nextClient,
+  })
+}
 </script>
 
 <style scoped>
@@ -234,6 +358,32 @@ function patch(which, fieldPatch) {
   grid-template-columns: 1fr auto;
   gap: 8px;
   align-items: center;
+}
+.afm-dob-row {
+  display: grid;
+  grid-template-columns: 1fr 110px;
+  gap: 8px;
+  align-items: center;
+}
+.afm-residency-cell {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.afm-residency-other {
+  font-size: 13px;
+}
+.afm-dob-age .suffix {
+  position: absolute;
+  right: 10px;
+  top: 50%;
+  transform: translateY(-50%);
+  font-size: 11px;
+  color: var(--text-faint);
+  pointer-events: none;
+}
+@media (max-width: 600px) {
+  .afm-dob-row { grid-template-columns: 1fr; }
 }
 .afm-purpose {
   display: flex;

--- a/Bold_Vision_CRM/src/components/base/AppSnackbar.vue
+++ b/Bold_Vision_CRM/src/components/base/AppSnackbar.vue
@@ -1,0 +1,44 @@
+<template>
+  <v-snackbar
+    v-model="state.show"
+    :color="state.color"
+    :timeout="state.timeout"
+    location="top"
+    multi-line
+  >
+    {{ state.text }}
+    <template #actions>
+      <button type="button" class="app-snackbar__close" @click="dismiss" aria-label="Dismiss">
+        <AppIcon name="x" :size="14" />
+      </button>
+    </template>
+  </v-snackbar>
+</template>
+
+<script setup>
+import { useFeedback } from '../../composables/useFeedback'
+import AppIcon from './AppIcon.vue'
+
+const { state, dismiss } = useFeedback()
+</script>
+
+<style scoped>
+.app-snackbar__close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 6px;
+  background: transparent;
+  color: inherit;
+  border: none;
+  cursor: pointer;
+  opacity: 0.85;
+  transition: background 0.12s, opacity 0.12s;
+}
+.app-snackbar__close:hover {
+  background: oklch(100% 0 0 / 0.15);
+  opacity: 1;
+}
+</style>

--- a/Bold_Vision_CRM/src/components/base/BaseSearchBar.vue
+++ b/Bold_Vision_CRM/src/components/base/BaseSearchBar.vue
@@ -8,6 +8,8 @@
     :name="name"
     :spellcheck="spellcheck"
     :autocapitalize="autocapitalize"
+    :maxlength="maxlength"
+    :counter="false"
     density="comfortable"
     variant="outlined"
     clearable
@@ -58,6 +60,12 @@ const props = defineProps({
   autocapitalize: {
     type: String,
     default: 'off',
+  },
+  // Cap input length at keystroke level. 200 chars is plenty for any search
+  // — anything longer is almost certainly paste-bomb / accidental input.
+  maxlength: {
+    type: [Number, String],
+    default: 200,
   },
 })
 

--- a/Bold_Vision_CRM/src/components/base/ConfirmDeleteDialog.vue
+++ b/Bold_Vision_CRM/src/components/base/ConfirmDeleteDialog.vue
@@ -1,0 +1,147 @@
+<template>
+  <v-dialog
+    v-model="isOpen"
+    :max-width="520"
+    transition="dialog-transition"
+    :scrim="'rgba(15,23,42,0.65)'"
+    :persistent="busy"
+  >
+    <div class="modal-card cdd-card">
+      <header class="modal-head">
+        <span class="ico cdd-ico"><AppIcon name="x" :size="18" /></span>
+        <div class="modal-head__text">
+          <h2>Delete {{ entityType }}</h2>
+          <div class="sub">This cannot be undone.</div>
+        </div>
+        <button class="close" aria-label="Close" :disabled="busy" @click="cancel">
+          <AppIcon name="x" :size="16" />
+        </button>
+      </header>
+
+      <div class="modal-body cdd-body">
+        <p class="cdd-warn">
+          You are about to permanently delete
+          <strong>{{ entityLabel || `this ${entityType}` }}</strong>.
+          Related data (notes, interactions, photos, interests) will also be removed.
+        </p>
+
+        <div class="field" :class="{ 'is-error': showError }">
+          <label for="cdd-input">
+            To confirm, type <strong>{{ confirmWord }}</strong> below.
+          </label>
+          <input
+            id="cdd-input"
+            ref="inputRef"
+            v-model="typed"
+            type="text"
+            class="input"
+            autocomplete="off"
+            :placeholder="confirmWord"
+            :disabled="busy"
+            @keyup.enter="onConfirm"
+          />
+          <p v-if="showError" class="field-error">
+            Type {{ confirmWord }} exactly to enable delete.
+          </p>
+        </div>
+      </div>
+
+      <div class="modal-foot">
+        <button class="btn btn-ghost" :disabled="busy" @click="cancel">Cancel</button>
+        <button
+          type="button"
+          class="btn cdd-btn-danger"
+          :disabled="!canConfirm || busy"
+          @click="onConfirm"
+        >
+          <AppIcon name="x" :size="14" />
+          {{ busy ? 'Deleting…' : `Delete ${entityType}` }}
+        </button>
+      </div>
+    </div>
+  </v-dialog>
+</template>
+
+<script setup>
+import { computed, nextTick, ref, watch } from 'vue'
+import AppIcon from './AppIcon.vue'
+
+const props = defineProps({
+  modelValue:  { type: Boolean, required: true },
+  entityType:  { type: String, required: true },   // e.g. "customer", "property"
+  entityLabel: { type: String, default: '' },      // e.g. customer name or property address
+  confirmWord: { type: String, default: 'CONFIRM' },
+  busy:        { type: Boolean, default: false },  // parent sets true while async delete in flight
+})
+
+const emit = defineEmits(['update:modelValue', 'confirm'])
+
+const isOpen = ref(props.modelValue)
+const typed = ref('')
+const inputRef = ref(null)
+const attempted = ref(false)
+
+watch(() => props.modelValue, (val) => {
+  isOpen.value = val
+  if (val) {
+    typed.value = ''
+    attempted.value = false
+    nextTick(() => inputRef.value?.focus())
+  }
+})
+watch(isOpen, (val) => emit('update:modelValue', val))
+
+const canConfirm = computed(() => typed.value.trim() === props.confirmWord)
+const showError = computed(() => attempted.value && !canConfirm.value)
+
+function cancel() {
+  if (props.busy) return
+  isOpen.value = false
+}
+
+function onConfirm() {
+  attempted.value = true
+  if (!canConfirm.value || props.busy) return
+  emit('confirm')
+}
+</script>
+
+<style scoped>
+.cdd-card { /* sits on top of modal-card chrome */ }
+.cdd-ico {
+  background: oklch(94% 0.04 27);
+  color: var(--danger, oklch(56% 0.20 27));
+}
+:root[data-theme="dark"] .cdd-ico {
+  background: oklch(28% 0.06 27);
+}
+.cdd-body {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 18px 20px;
+}
+.cdd-warn {
+  margin: 0;
+  font-size: 13.5px;
+  line-height: 1.5;
+  color: var(--text);
+}
+.cdd-warn strong {
+  color: var(--text);
+  font-weight: 600;
+}
+.cdd-btn-danger {
+  background: var(--danger, oklch(56% 0.20 27));
+  color: oklch(100% 0 0);
+  border: none;
+}
+.cdd-btn-danger:hover:not(:disabled) {
+  background: oklch(50% 0.20 27);
+}
+.cdd-btn-danger:disabled {
+  background: var(--surface-sunk);
+  color: var(--text-faint);
+  cursor: not-allowed;
+}
+</style>

--- a/Bold_Vision_CRM/src/components/customer/AddCustomerDialog.vue
+++ b/Bold_Vision_CRM/src/components/customer/AddCustomerDialog.vue
@@ -23,7 +23,7 @@
         <!-- Contact -->
         <div class="modal-section">
           <h4>Contact</h4>
-          <div class="field">
+          <div class="field" :class="{ 'is-error': errors.name }">
             <label for="ac-name">Full name</label>
             <div class="input-affix">
               <span class="prefix"><AppIcon name="user" :size="14" /></span>
@@ -34,11 +34,23 @@
                 class="input has-prefix"
                 autocomplete="name"
                 placeholder="e.g. Bora Chhem"
+                :maxlength="LIMITS.name.max"
+                @input="clearError('name')"
+                @blur="validateField('name'); checkDuplicates()"
               />
             </div>
+            <p v-if="errors.name" class="field-error">{{ errors.name }}</p>
+            <p v-if="duplicates.name" class="dup-warn">
+              <AppIcon name="user" :size="12" />
+              Same name as
+              <RouterLink :to="`/customers/${duplicates.name.id}`" class="dup-link" @click="close">
+                {{ duplicates.name.name }}
+              </RouterLink>
+              — different person? Save anyway.
+            </p>
           </div>
           <div class="split-grid cols-2">
-            <div class="field">
+            <div class="field" :class="{ 'is-error': errors.phone }">
               <label for="ac-phone">Phone</label>
               <div class="input-affix">
                 <span class="prefix"><AppIcon name="phone" :size="14" /></span>
@@ -49,10 +61,22 @@
                   class="input has-prefix"
                   autocomplete="tel"
                   placeholder="0412 345 678"
+                  :maxlength="LIMITS.phone.max"
+                  @input="clearError('phone'); clearError('_')"
+                  @blur="validateField('phone'); checkDuplicates()"
                 />
               </div>
+              <p v-if="errors.phone" class="field-error">{{ errors.phone }}</p>
+              <p v-if="duplicates.phone" class="dup-error">
+                <AppIcon name="phone" :size="12" />
+                This phone already belongs to
+                <RouterLink :to="`/customers/${duplicates.phone.id}`" class="dup-link" @click="close">
+                  {{ duplicates.phone.name || 'an existing customer' }}
+                </RouterLink>
+                — open them or change the number.
+              </p>
             </div>
-            <div class="field">
+            <div class="field" :class="{ 'is-error': errors.email }">
               <label for="ac-email">Email</label>
               <div class="input-affix">
                 <span class="prefix"><AppIcon name="mail" :size="14" /></span>
@@ -63,11 +87,23 @@
                   class="input has-prefix"
                   autocomplete="email"
                   placeholder="name@example.com"
+                  :maxlength="LIMITS.email.max"
+                  @input="clearError('email'); clearError('_')"
+                  @blur="validateField('email'); checkDuplicates()"
                 />
               </div>
+              <p v-if="errors.email" class="field-error">{{ errors.email }}</p>
+              <p v-if="duplicates.email" class="dup-error">
+                <AppIcon name="mail" :size="12" />
+                This email already belongs to
+                <RouterLink :to="`/customers/${duplicates.email.id}`" class="dup-link" @click="close">
+                  {{ duplicates.email.name || 'an existing customer' }}
+                </RouterLink>
+                — open them or change the address.
+              </p>
             </div>
           </div>
-          <div class="field">
+          <div class="field" :class="{ 'is-error': errors.agent }">
             <label for="ac-agent">Agent</label>
             <div class="input-affix">
               <span class="prefix"><AppIcon name="user" :size="14" /></span>
@@ -77,9 +113,14 @@
                 type="text"
                 class="input has-prefix"
                 placeholder="Who owns this customer (e.g. Sarah Liang)"
+                :maxlength="LIMITS.agent.max"
+                @input="clearError('agent')"
+                @blur="validateField('agent')"
               />
             </div>
+            <p v-if="errors.agent" class="field-error">{{ errors.agent }}</p>
           </div>
+          <p v-if="errors._" class="form-error">{{ errors._ }}</p>
         </div>
 
         <!-- Categorize -->
@@ -126,26 +167,35 @@
               <span class="field-action">Only visible to your team</span>
             </div>
             <textarea
-
               v-model="form.notes"
               class="textarea"
               rows="3"
               placeholder="Anything important to remember…"
+              :maxlength="LIMITS.notes.max"
+              @input="clearError('notes')"
+              @blur="validateField('notes')"
             ></textarea>
+            <p v-if="errors.notes" class="field-error">{{ errors.notes }}</p>
           </div>
         </div>
       </div>
 
       <div class="modal-foot modal-foot--split">
         <span class="hint">
-          <span class="hint-dot" :class="{ ok: canSave }"></span>
-          {{ canSave ? 'Ready to save' : 'Add a name and phone or email' }}
+          <span class="hint-dot" :class="hintDotClass"></span>
+          <template v-if="hasBlockingDuplicate">Duplicate phone or email — must be unique</template>
+          <template v-else-if="duplicates.name">Same name as another customer — save anyway?</template>
+          <template v-else>{{ canSave ? 'Ready to save' : 'Add a name and phone or email' }}</template>
         </span>
         <div class="actions">
           <button class="btn btn-ghost" @click="close">Cancel</button>
-          <button class="btn btn-primary" :disabled="!canSave" @click="handleSave">
+          <button
+            class="btn btn-primary"
+            :disabled="hasBlockingDuplicate"
+            @click="handleSave"
+          >
             <AppIcon name="plus" :size="14" />
-            Add customer
+            {{ duplicates.name && !hasBlockingDuplicate ? 'Save anyway' : 'Add customer' }}
           </button>
         </div>
       </div>
@@ -155,7 +205,11 @@
 
 <script setup>
 import { computed, ref, watch } from 'vue'
+import { RouterLink } from 'vue-router'
 import AppIcon from '../base/AppIcon.vue'
+import { validateCustomerForm, findDuplicateCustomers, LIMITS } from '../../utils/validators'
+import { useFeedback } from '../../composables/useFeedback'
+import { useCustomerStore } from '../../stores/customerStore'
 
 const STATUS_OPTIONS = [
   { value: 'Hot',  label: 'Hot',  toneClass: 'is-hot',  dot: 'var(--hot)'  },
@@ -190,10 +244,36 @@ const emit = defineEmits(['update:modelValue', 'add'])
 
 const isOpen = ref(props.modelValue)
 const form = ref(makeEmptyForm())
+const errors = ref({})
+const duplicates = ref({})           // { phone?: customer, email?: customer }
+const { notifyError } = useFeedback()
+const customerStore = useCustomerStore()
+
+// Phone + email are hard blocks (no override). Name is a soft warn.
+const hasBlockingDuplicate = computed(
+  () => !!(duplicates.value.phone || duplicates.value.email),
+)
+const hintDotClass = computed(() => {
+  if (hasBlockingDuplicate.value) return 'err'
+  if (duplicates.value.name) return 'warn'
+  if (canSave.value) return 'ok'
+  return ''
+})
+
+function checkDuplicates() {
+  duplicates.value = findDuplicateCustomers(
+    { phone: form.value.phone, email: form.value.email, name: form.value.name },
+    customerStore.customers,
+  )
+}
 
 watch(() => props.modelValue, (val) => {
   isOpen.value = val
-  if (val) form.value = makeEmptyForm()
+  if (val) {
+    form.value = makeEmptyForm()
+    errors.value = {}
+    duplicates.value = {}
+  }
 })
 watch(isOpen, (val) => emit('update:modelValue', val))
 
@@ -202,12 +282,47 @@ const canSave = computed(() => {
   return !!f.name.trim() && (!!f.phone.trim() || !!f.email.trim())
 })
 
+function clearError(field) {
+  if (errors.value[field]) {
+    const { [field]: _, ...rest } = errors.value
+    errors.value = rest
+  }
+}
+
+// Run the full composite validator but only surface the error for the given
+// field. Keeps the at-least-one-contact check live across phone+email blur.
+function validateField(field) {
+  const result = validateCustomerForm(form.value) ?? {}
+  if (result[field]) errors.value = { ...errors.value, [field]: result[field] }
+  else clearError(field)
+  // Refresh the form-level "at least one contact" message based on current state
+  if (result._) errors.value = { ...errors.value, _: result._ }
+  else clearError('_')
+}
+
 function close() {
   isOpen.value = false
 }
 
 function handleSave() {
-  if (!canSave.value) return
+  const result = validateCustomerForm(form.value)
+  if (result) {
+    errors.value = result
+    // Surface the first field's message as a toast so the user notices even
+    // if the offending field is scrolled off-screen
+    const first = result._ ?? Object.values(result)[0]
+    notifyError(first)
+    return
+  }
+  // Re-check duplicates defensively (Enter key may bypass @blur)
+  checkDuplicates()
+  if (hasBlockingDuplicate.value) {
+    const target = duplicates.value.phone ?? duplicates.value.email
+    const field  = duplicates.value.phone ? 'phone number' : 'email'
+    notifyError(`This ${field} already belongs to ${target.name || 'an existing customer'}.`)
+    return
+  }
+  errors.value = {}
   emit('add', { ...form.value })
 }
 </script>
@@ -222,5 +337,52 @@ function handleSave() {
   flex-shrink: 0;
   transition: background .15s;
 }
-.hint-dot.ok { background: var(--success, var(--accent)); }
+.hint-dot.ok   { background: var(--success, var(--accent)); }
+.hint-dot.warn { background: oklch(72% 0.16 75); }
+.hint-dot.err  { background: var(--danger, oklch(56% 0.20 27)); }
+
+/* Soft duplicate warning (name) — yellow, allows override */
+.dup-warn {
+  margin: 4px 0 0;
+  padding: 6px 10px;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  color: oklch(45% 0.13 75);
+  background: oklch(96% 0.04 75);
+  border: 1px solid oklch(80% 0.10 75);
+  border-radius: var(--r-md);
+}
+:root[data-theme="dark"] .dup-warn {
+  background: oklch(28% 0.06 75);
+  border-color: oklch(40% 0.10 75);
+  color: oklch(85% 0.10 75);
+}
+
+/* Hard duplicate error (phone / email) — red, blocks save */
+.dup-error {
+  margin: 4px 0 0;
+  padding: 6px 10px;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  color: var(--danger, oklch(45% 0.18 27));
+  background: oklch(96% 0.03 27);
+  border: 1px solid oklch(80% 0.10 27);
+  border-radius: var(--r-md);
+}
+:root[data-theme="dark"] .dup-error {
+  background: oklch(28% 0.06 27);
+  border-color: oklch(40% 0.10 27);
+  color: oklch(85% 0.10 27);
+}
+
+.dup-link {
+  color: inherit;
+  text-decoration: underline;
+  font-weight: 600;
+}
+.dup-link:hover { opacity: 0.85; }
 </style>

--- a/Bold_Vision_CRM/src/components/customer/CustomerInterestsPanel.vue
+++ b/Bold_Vision_CRM/src/components/customer/CustomerInterestsPanel.vue
@@ -101,6 +101,7 @@
                   type="text"
                   :placeholder="selectedProperty ? selectedProperty.address : 'Search by address or suburb'"
                   autocomplete="off"
+                  maxlength="200"
                 />
               </div>
               <div v-if="filteredProperties.length" class="cd-int-picker__list">

--- a/Bold_Vision_CRM/src/components/followups/KanbanCard.vue
+++ b/Bold_Vision_CRM/src/components/followups/KanbanCard.vue
@@ -45,7 +45,7 @@
         <button
           type="button"
           class="qa-btn done"
-          title="Mark contacted"
+          title="Mark followed up"
           @click.prevent.stop="$emit('mark-contacted')"
           @mousedown.stop
         >
@@ -95,7 +95,7 @@ const overdueDays = computed(() => {
 })
 
 const lastContactLabel = computed(() => {
-  if (!props.customer.lastContactedAt) return 'Never contacted'
+  if (!props.customer.lastContactedAt) return 'No follow-ups yet'
   const d = new Date(props.customer.lastContactedAt)
   return 'Last: ' + d.toLocaleDateString('en-AU', { day: 'numeric', month: 'short' })
 })

--- a/Bold_Vision_CRM/src/components/properties/AddPropertyDialog.vue
+++ b/Bold_Vision_CRM/src/components/properties/AddPropertyDialog.vue
@@ -14,7 +14,7 @@
       </header>
 
       <div class="dialog-body" tabindex="-1">
-        <PropertyForm v-model="draft" />
+        <PropertyForm ref="propertyFormRef" v-model="draft" />
       </div>
 
       <footer class="dialog-footer">
@@ -27,9 +27,14 @@
 </template>
 
 <script setup>
+import { ref } from 'vue'
 import PropertyForm from './PropertiesForm.vue'
 import { useFilterDialogState } from '../../composables/useFilterDialogState'
 import { createEmptyPropertyDraft } from '../../constants/propertyDefaults'
+import { useFeedback } from '../../composables/useFeedback'
+
+const { notifyError } = useFeedback()
+const propertyFormRef = ref(null)
 
 const props = defineProps({
   modelValue: { type: Boolean, default: false },
@@ -59,6 +64,12 @@ const { draft, isOpen, close } = useFilterDialogState({
 })
 
 function handleConfirm() {
+  const errs = propertyFormRef.value?.validate()
+  if (errs) {
+    const first = errs._ ?? Object.values(errs)[0]
+    notifyError(first)
+    return
+  }
   emit('confirm', {
     ...draft,
     gallery: Array.isArray(draft.gallery) ? [...draft.gallery] : [],

--- a/Bold_Vision_CRM/src/components/properties/BroadcastPanel.vue
+++ b/Bold_Vision_CRM/src/components/properties/BroadcastPanel.vue
@@ -196,6 +196,13 @@ const sending          = ref(false)
 const sent             = ref(false)
 const lastSentCount    = ref(0)
 
+// Idempotency key (audit C10). Pinned for the lifetime of THIS dialog so that
+// a network retry of an in-flight Send hits the same key — the edge fn
+// recognises it as a retry, resends only the failed recipients, and the agent
+// doesn't accidentally double-broadcast. A fresh dialog open generates a new
+// key (fresh broadcast).
+const idempotencyKey = ref(crypto.randomUUID())
+
 // Media: photos + floor plans available for this property.
 const propertyMedia = ref([])
 const thumbUrls     = ref({})     // { [storage_path]: signedUrl } — populated lazily on mount
@@ -295,8 +302,8 @@ async function send() {
       propertyId: props.property.id,
       body: messageBody.value,
       audienceFilter: selectedAudience.value,
-      customers: eligibleRecipients.value,
       includeMedia: includeMedia.value && hasMedia.value,
+      idempotencyKey: idempotencyKey.value,
     })
     lastSentCount.value = result.sent
     sent.value = true

--- a/Bold_Vision_CRM/src/components/properties/BroadcastPanel.vue
+++ b/Bold_Vision_CRM/src/components/properties/BroadcastPanel.vue
@@ -100,12 +100,15 @@
 
         <div class="tg-edit-label">
           <span>Message</span>
-          <span class="count">{{ messageBody.length }} chars</span>
+          <span class="count" :class="{ 'count--warn': nearLimit, 'count--err': atLimit }">
+            {{ messageBody.length }} / {{ LIMITS.messageBody.max }}
+          </span>
         </div>
         <textarea
           v-model="messageBody"
           class="tg-edit"
           placeholder="Write your broadcast…"
+          :maxlength="LIMITS.messageBody.max"
         />
 
         <!-- Media toggle: include property photos + floor plans -->
@@ -162,9 +165,6 @@
       </div>
     </div>
 
-    <v-snackbar v-model="snackbar.show" :color="snackbar.color" timeout="4000">
-      {{ snackbar.text }}
-    </v-snackbar>
   </div>
 </template>
 
@@ -177,6 +177,10 @@ import { useCustomerStore } from '../../stores/customerStore'
 import { createBroadcast } from '../../services/messagesService'
 import { listPropertyMedia, getSignedUrl } from '../../services/mediaService'
 import AppIcon from '../base/AppIcon.vue'
+import { validateBroadcast, LIMITS } from '../../utils/validators'
+import { useFeedback } from '../../composables/useFeedback'
+
+const { notifySuccess, notifyError, notifyWarning, notifyFromError } = useFeedback()
 
 const ALBUM_PREVIEW_MAX = 4   // Telegram caps the album at 10; preview shows up to 4 thumbs + "+N"
 
@@ -217,7 +221,10 @@ const albumThumbs = computed(() =>
 )
 const albumOverflow = computed(() => Math.max(0, orderedMedia.value.length - ALBUM_PREVIEW_MAX))
 
-const snackbar = ref({ show: false, text: '', color: 'success' })
+// Char-count warning thresholds — purely visual, doesn't block typing
+// (maxlength on the textarea is the hard cap)
+const nearLimit = computed(() => messageBody.value.length >= LIMITS.messageBody.max - 200)
+const atLimit   = computed(() => messageBody.value.length >= LIMITS.messageBody.max)
 
 const audienceOptions = [
   { label: 'All',  value: 'All',  tone: 'all'  },
@@ -273,7 +280,15 @@ function buildDefaultMessage() {
 }
 
 async function send() {
-  if (eligibleRecipients.value.length === 0 || !messageBody.value.trim()) return
+  // Hard pre-flight validation: body length 1..4096, recipient cap, non-empty list.
+  const errs = validateBroadcast({
+    body: messageBody.value,
+    recipients: eligibleRecipients.value,
+  })
+  if (errs) {
+    notifyError(errs.body ?? errs.recipients ?? 'Invalid broadcast')
+    return
+  }
   sending.value = true
   try {
     const result = await createBroadcast({
@@ -285,13 +300,15 @@ async function send() {
     })
     lastSentCount.value = result.sent
     sent.value = true
-    snackbar.value = {
-      show: true,
-      text: `Sent to ${result.sent} customer${result.sent === 1 ? '' : 's'}${result.failed ? ` (${result.failed} failed)` : ''}${result.includedMedia ? ' with media' : ''}.`,
-      color: result.failed ? 'warning' : 'success',
+    const mediaNote = result.includedMedia ? ' with media' : ''
+    const tail = `Sent to ${result.sent} customer${result.sent === 1 ? '' : 's'}${mediaNote}`
+    if (result.failed) {
+      notifyWarning(`${tail} (${result.failed} failed)`)
+    } else {
+      notifySuccess(tail)
     }
   } catch (e) {
-    snackbar.value = { show: true, text: `Error: ${e.message}`, color: 'error' }
+    notifyFromError(e, 'Broadcast failed')
   } finally {
     sending.value = false
   }
@@ -578,6 +595,8 @@ onMounted(async () => {
   font-weight: 500;
   font-variant-numeric: tabular-nums;
 }
+.tg-edit-label .count--warn { color: oklch(60% 0.16 75); }
+.tg-edit-label .count--err  { color: var(--danger, oklch(56% 0.20 27)); font-weight: 600; }
 .tg-edit {
   width: 100%;
   background: var(--surface-2);

--- a/Bold_Vision_CRM/src/components/properties/PropertiesForm.vue
+++ b/Bold_Vision_CRM/src/components/properties/PropertiesForm.vue
@@ -6,7 +6,7 @@
       <h4 class="pd-section-head">Basic details</h4>
 
       <div class="field-stack">
-        <div class="field">
+        <div class="field" :class="{ 'is-error': errors.address }">
           <label for="pf-address">Street address</label>
           <input
             id="pf-address"
@@ -17,11 +17,15 @@
             autocomplete="street-address"
             placeholder="e.g. 12 Main Street"
             required
+            :maxlength="LIMITS.address.max"
+            @input="clearError('address')"
+            @blur="validateFieldNamed('address')"
           />
+          <p v-if="errors.address" class="field-error">{{ errors.address }}</p>
         </div>
 
         <div class="grid-2-1-1">
-          <div class="field">
+          <div class="field" :class="{ 'is-error': errors.suburb }">
             <label for="pf-suburb">Suburb</label>
             <input
               id="pf-suburb"
@@ -30,7 +34,11 @@
               type="text"
               name="address-level2"
               autocomplete="address-level2"
+              :maxlength="LIMITS.suburb.max"
+              @input="clearError('suburb')"
+              @blur="validateFieldNamed('suburb')"
             />
+            <p v-if="errors.suburb" class="field-error">{{ errors.suburb }}</p>
           </div>
           <div class="field">
             <label for="pf-state">State</label>
@@ -44,7 +52,7 @@
               <option v-for="s in stateOptions" :key="s" :value="s">{{ s }}</option>
             </select>
           </div>
-          <div class="field">
+          <div class="field" :class="{ 'is-error': errors.postcode }">
             <label for="pf-postcode">Postcode</label>
             <input
               id="pf-postcode"
@@ -54,7 +62,11 @@
               inputmode="numeric"
               name="postal-code"
               autocomplete="postal-code"
+              maxlength="4"
+              @input="clearError('postcode')"
+              @blur="validateFieldNamed('postcode')"
             />
+            <p v-if="errors.postcode" class="field-error">{{ errors.postcode }}</p>
           </div>
         </div>
       </div>
@@ -83,7 +95,7 @@
               <option v-for="s in statusOptions" :key="s" :value="s">{{ s }}</option>
             </select>
           </div>
-          <div class="field">
+          <div class="field" :class="{ 'is-error': errors.priceMin }">
             <label for="pf-price-min">Price (min)</label>
             <div class="input-affix">
               <span class="prefix">$</span>
@@ -94,11 +106,13 @@
                 type="text"
                 placeholder="e.g. 850k or 1.2m"
                 autocomplete="off"
-                @blur="normalizePriceInput('min')"
+                @input="clearError('priceMin'); clearError('priceMax')"
+                @blur="normalizePriceInput('min'); validateFieldNamed('priceMin'); validateFieldNamed('priceMax')"
               />
             </div>
+            <p v-if="errors.priceMin" class="field-error">{{ errors.priceMin }}</p>
           </div>
-          <div class="field">
+          <div class="field" :class="{ 'is-error': errors.priceMax }">
             <label for="pf-price-max">Price (max, optional)</label>
             <div class="input-affix">
               <span class="prefix">$</span>
@@ -109,9 +123,11 @@
                 type="text"
                 placeholder="leave blank for single price"
                 autocomplete="off"
-                @blur="normalizePriceInput('max')"
+                @input="clearError('priceMax')"
+                @blur="normalizePriceInput('max'); validateFieldNamed('priceMax')"
               />
             </div>
+            <p v-if="errors.priceMax" class="field-error">{{ errors.priceMax }}</p>
           </div>
         </div>
 
@@ -141,7 +157,7 @@
       </div>
 
       <div class="grid-5">
-        <div class="field">
+        <div class="field" :class="{ 'is-error': errors.bedrooms }">
           <label for="pf-bedrooms">Bedrooms</label>
           <input
             id="pf-bedrooms"
@@ -149,10 +165,13 @@
             class="input"
             type="number"
             min="0"
-            @input="(e) => updateNumberField('bedrooms', e.target.value)"
+            :max="LIMITS.bedrooms.max"
+            @input="(e) => { updateNumberField('bedrooms', e.target.value); clearError('bedrooms') }"
+            @blur="validateFieldNamed('bedrooms')"
           />
+          <p v-if="errors.bedrooms" class="field-error">{{ errors.bedrooms }}</p>
         </div>
-        <div class="field">
+        <div class="field" :class="{ 'is-error': errors.bathrooms }">
           <label for="pf-bathrooms">Bathrooms</label>
           <input
             id="pf-bathrooms"
@@ -160,10 +179,13 @@
             class="input"
             type="number"
             min="0"
-            @input="(e) => updateNumberField('bathrooms', e.target.value)"
+            :max="LIMITS.bathrooms.max"
+            @input="(e) => { updateNumberField('bathrooms', e.target.value); clearError('bathrooms') }"
+            @blur="validateFieldNamed('bathrooms')"
           />
+          <p v-if="errors.bathrooms" class="field-error">{{ errors.bathrooms }}</p>
         </div>
-        <div class="field">
+        <div class="field" :class="{ 'is-error': errors.carSpaces }">
           <label for="pf-cars">Car spaces</label>
           <input
             id="pf-cars"
@@ -171,10 +193,13 @@
             class="input"
             type="number"
             min="0"
-            @input="(e) => updateNumberField('carSpaces', e.target.value, { mirrorField: 'carparkSpaces' })"
+            :max="LIMITS.carSpaces.max"
+            @input="(e) => { updateNumberField('carSpaces', e.target.value, { mirrorField: 'carparkSpaces' }); clearError('carSpaces') }"
+            @blur="validateFieldNamed('carSpaces')"
           />
+          <p v-if="errors.carSpaces" class="field-error">{{ errors.carSpaces }}</p>
         </div>
-        <div class="field">
+        <div class="field" :class="{ 'is-error': errors.landSizeSqm }">
           <label for="pf-land">Land size</label>
           <div class="input-affix">
             <input
@@ -184,12 +209,14 @@
               type="text"
               inputmode="numeric"
               autocomplete="off"
-              @blur="normalizeSqmInput('land')"
+              @input="clearError('landSizeSqm')"
+              @blur="normalizeSqmInput('land'); validateFieldNamed('landSizeSqm')"
             />
             <span class="suffix">m²</span>
           </div>
+          <p v-if="errors.landSizeSqm" class="field-error">{{ errors.landSizeSqm }}</p>
         </div>
-        <div class="field">
+        <div class="field" :class="{ 'is-error': errors.houseSizeSqm }">
           <label for="pf-house">House size</label>
           <div class="input-affix">
             <input
@@ -199,10 +226,12 @@
               type="text"
               inputmode="numeric"
               autocomplete="off"
-              @blur="normalizeSqmInput('house')"
+              @input="clearError('houseSizeSqm')"
+              @blur="normalizeSqmInput('house'); validateFieldNamed('houseSizeSqm')"
             />
             <span class="suffix">m²</span>
           </div>
+          <p v-if="errors.houseSizeSqm" class="field-error">{{ errors.houseSizeSqm }}</p>
         </div>
       </div>
 
@@ -213,7 +242,7 @@
       <h4 class="pd-section-head">Notes &amp; description</h4>
 
       <div class="field-stack">
-        <div class="field">
+        <div class="field" :class="{ 'is-error': errors.description }">
           <label for="pf-description">Public description</label>
           <textarea
             id="pf-description"
@@ -221,9 +250,13 @@
             class="textarea"
             rows="4"
             placeholder="Shown on the listing"
+            :maxlength="LIMITS.description.max"
+            @input="clearError('description')"
+            @blur="validateFieldNamed('description')"
           />
+          <p v-if="errors.description" class="field-error">{{ errors.description }}</p>
         </div>
-        <div class="field">
+        <div class="field" :class="{ 'is-error': errors.notes }">
           <label for="pf-notes">Internal notes</label>
           <textarea
             id="pf-notes"
@@ -231,7 +264,11 @@
             class="textarea"
             rows="3"
             placeholder="Only visible to your team"
+            :maxlength="LIMITS.notes.max"
+            @input="clearError('notes')"
+            @blur="validateFieldNamed('notes')"
           />
+          <p v-if="errors.notes" class="field-error">{{ errors.notes }}</p>
         </div>
       </div>
     </section>
@@ -241,6 +278,7 @@
 <script setup>
 import { computed, ref, watch } from 'vue'
 import { formatPrice, formatPriceSingle, parsePriceInput, formatSqm } from '../../utils/formatters'
+import { validatePropertyForm, LIMITS } from '../../utils/validators'
 
 const typeOptions = ['House', 'Townhouse', 'Villa', 'Apartment']
 const statusOptions = ['On Market', 'Coming Soon', 'Under Contract', 'Sold', 'Off Market', 'Withdrawn']
@@ -365,6 +403,34 @@ function updateNumberField(field, value, options = {}) {
     form.value[options.mirrorField] = form.value[field]
   }
 }
+
+// ── Validation ────────────────────────────────────────────────────────────
+const errors = ref({})
+
+function clearError(field) {
+  if (errors.value[field]) {
+    const { [field]: _, ...rest } = errors.value
+    errors.value = rest
+  }
+}
+
+// Run the full composite validator but surface only the requested field's
+// error. Keeps the priceMin/priceMax cross-check live across both blur events.
+function validateFieldNamed(field) {
+  const all = validatePropertyForm(form.value) ?? {}
+  if (all[field]) errors.value = { ...errors.value, [field]: all[field] }
+  else clearError(field)
+}
+
+// Called from the parent before save. Populates `errors` and returns the
+// errors object (or null if clean).
+function validate() {
+  const result = validatePropertyForm(form.value)
+  errors.value = result ?? {}
+  return result
+}
+
+defineExpose({ validate })
 </script>
 
 <style scoped>

--- a/Bold_Vision_CRM/src/components/properties/PropertyInterestsPanel.vue
+++ b/Bold_Vision_CRM/src/components/properties/PropertyInterestsPanel.vue
@@ -88,6 +88,7 @@
                   type="text"
                   :placeholder="selectedCustomer ? selectedCustomer.name : 'Search by name, phone or email'"
                   autocomplete="off"
+                  maxlength="200"
                 />
               </div>
               <div v-if="filteredCustomers.length" class="customer-list">

--- a/Bold_Vision_CRM/src/composables/useFeedback.js
+++ b/Bold_Vision_CRM/src/composables/useFeedback.js
@@ -1,0 +1,39 @@
+import { reactive } from 'vue'
+
+// Module-scoped state — shared across every component that calls useFeedback().
+// Read by the single <AppSnackbar /> mounted in App.vue.
+const state = reactive({
+  show: false,
+  text: '',
+  color: 'success',   // 'success' | 'error' | 'info' | 'warning'
+  timeout: 4000,
+})
+
+function notify(text, color, timeout) {
+  state.text = String(text ?? '')
+  state.color = color
+  state.timeout = timeout
+  // Force re-trigger if the same message is sent twice in a row
+  state.show = false
+  // Defer to next tick so v-snackbar sees the transition
+  Promise.resolve().then(() => { state.show = true })
+}
+
+export function useFeedback() {
+  return {
+    state,
+    notifySuccess(text, timeout = 4000) { notify(text, 'success', timeout) },
+    notifyError(text, timeout = -1)     { notify(text, 'error', timeout) },  // no auto-dismiss
+    notifyInfo(text, timeout = 4000)    { notify(text, 'info', timeout) },
+    notifyWarning(text, timeout = 6000) { notify(text, 'warning', timeout) },
+
+    // Convenience: pull the human-readable message from any error and surface
+    // as an error toast. Handles ValidationError specifically.
+    notifyFromError(err, prefix = '') {
+      const msg = err?.firstMessage ?? err?.message ?? String(err)
+      notify(prefix ? `${prefix}: ${msg}` : msg, 'error', -1)
+    },
+
+    dismiss() { state.show = false },
+  }
+}

--- a/Bold_Vision_CRM/src/main.js
+++ b/Bold_Vision_CRM/src/main.js
@@ -21,7 +21,14 @@ app.use(pinia)
 app.use(router)
 app.use(vuetify)
 
+// C12: Await auth init BEFORE mount. Without this, the router guard could
+// fire while the store is still empty — protected routes would briefly flash
+// the login page even for legitimate logged-in users (and worse on slow
+// connections, could render a protected view with no data for a frame).
+//
+// authStore.init() never throws — errors are captured into authStore.initError
+// and the user is shown a connection-error alert on the login page.
 import { useAuthStore } from './stores/authStore'
-useAuthStore().init()
+await useAuthStore().init()
 
 app.mount('#app')

--- a/Bold_Vision_CRM/src/router/index.js
+++ b/Bold_Vision_CRM/src/router/index.js
@@ -8,6 +8,9 @@ import FollowUpsView from '../views/FollowUpsView.vue'
 import MessageHistoryView from '../views/MessageHistoryView.vue'
 import LoginView from '../views/LoginView.vue'
 import { getSession } from '../services/authService'
+import { useAuthStore } from '../stores/authStore'
+import { usePropertyStore } from '../stores/propertyStore'
+import { useCustomerStore } from '../stores/customerStore'
 
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
@@ -68,17 +71,33 @@ const router = createRouter({
   ],
 })
 
-// Guard re-queries Supabase getSession() on every navigation. We tried
-// reading from the auth store (C12 — to dedupe the redundant lookup) but
-// that broke session persistence on hard refresh, even though the store
-// WAS populated and localStorage HAD the token. Suspect: top-level await
-// + Pinia store-to-guard reactivity timing in dev mode. Re-investigate
-// later; for now the extra network call is cheap (getSession reads from
-// localStorage, no remote roundtrip when the token is still valid).
+// C12: store-first guard with getSession fallback.
+//
+// Fast path (99% of navigations): the auth store has a session from a
+// prior init() or sign-in. Guard reads `authStore.session` synchronously,
+// no network call, no localStorage read.
+//
+// Fallback path: the store is empty on the first request after hard-
+// refresh. main.js's `await authStore.init()` calls getSession(), but
+// the SDK can return null on the very first call (a known Supabase-JS
+// startup race) — the real session lands via the onAuthChange
+// INITIAL_SESSION event slightly later. Our fallback uses getSession()
+// directly to verify against Supabase storage. If a session exists,
+// heal the store AND kick off the same data fetches that init() would
+// have triggered — otherwise the route renders with empty stores until
+// onAuthChange catches up, flashing "no properties" / "no customers".
 router.beforeEach(async (to) => {
   if (!to.meta.requiresAuth) return true
+  const authStore = useAuthStore()
+  if (authStore.session) return true
   const session = await getSession()
   if (!session) return { name: 'login', query: { redirect: to.fullPath } }
+  authStore.session = session
+  authStore.user = session.user ?? null
+  // Same fetches as authStore.init() would do once it sees a session.
+  // Safe if they were already triggered — both stores dedupe / re-populate.
+  usePropertyStore().fetchProperties()
+  useCustomerStore().fetchCustomers()
   return true
 })
 

--- a/Bold_Vision_CRM/src/router/index.js
+++ b/Bold_Vision_CRM/src/router/index.js
@@ -68,6 +68,13 @@ const router = createRouter({
   ],
 })
 
+// Guard re-queries Supabase getSession() on every navigation. We tried
+// reading from the auth store (C12 — to dedupe the redundant lookup) but
+// that broke session persistence on hard refresh, even though the store
+// WAS populated and localStorage HAD the token. Suspect: top-level await
+// + Pinia store-to-guard reactivity timing in dev mode. Re-investigate
+// later; for now the extra network call is cheap (getSession reads from
+// localStorage, no remote roundtrip when the token is still valid).
 router.beforeEach(async (to) => {
   if (!to.meta.requiresAuth) return true
   const session = await getSession()

--- a/Bold_Vision_CRM/src/services/assessmentsService.js
+++ b/Bold_Vision_CRM/src/services/assessmentsService.js
@@ -1,4 +1,11 @@
 import { supabase } from './supabase'
+import {
+  validateAssessmentSection,
+  validateMaxLength,
+  validateDateMaxFuture,
+  ValidationError,
+  LIMITS,
+} from '../utils/validators'
 
 // Section payload shapes (JSONB columns on customer_assessments).
 // PDF page 1 → personal/employment/income/assets/liabilities;
@@ -80,6 +87,12 @@ export async function updateSection(assessmentId, sectionKey, payload, touchedSe
   if (!SECTION_KEYS.includes(sectionKey)) {
     throw new Error(`Unknown assessment section: ${sectionKey}`)
   }
+  // Validate the section payload before sending. Throws ValidationError on
+  // length / format / range violations so the autosave halts and the store
+  // surfaces a toast rather than silently writing garbage.
+  const errs = validateAssessmentSection(sectionKey, payload)
+  if (errs) throw new ValidationError(errs, `Invalid ${sectionKey} section`)
+
   const patch = { [sectionKey]: payload }
   if (Array.isArray(touchedSections)) patch.touched_sections = touchedSections
   const { data, error } = await supabase
@@ -93,6 +106,22 @@ export async function updateSection(assessmentId, sectionKey, payload, touchedSe
 }
 
 export async function updateMeta(assessmentId, partial) {
+  // Validate top-level meta fields the same way
+  const errors = {}
+  if (partial.consultantName !== undefined) {
+    const e = validateMaxLength(partial.consultantName, LIMITS.assessmentText.max, 'Consultant')
+    if (e) errors.consultantName = e
+  }
+  if (partial.brokerName !== undefined) {
+    const e = validateMaxLength(partial.brokerName, LIMITS.assessmentText.max, 'Broker')
+    if (e) errors.brokerName = e
+  }
+  if (partial.nextAppointmentAt !== undefined && partial.nextAppointmentAt) {
+    const e = validateDateMaxFuture(partial.nextAppointmentAt, 5, 'Next appointment')
+    if (e) errors.nextAppointmentAt = e
+  }
+  if (Object.keys(errors).length) throw new ValidationError(errors)
+
   const patch = {}
   if (partial.consultantName !== undefined) patch.consultant_name = partial.consultantName
   if (partial.brokerName !== undefined) patch.broker_name = partial.brokerName

--- a/Bold_Vision_CRM/src/services/customersService.js
+++ b/Bold_Vision_CRM/src/services/customersService.js
@@ -1,4 +1,67 @@
 import { supabase } from './supabase'
+import {
+  validateCustomerForm,
+  validateFeedback,
+  validateRequired,
+  validateMaxLength,
+  validatePhone,
+  validateEmail,
+  validateTelegramChatId,
+  ValidationError,
+  LIMITS,
+} from '../utils/validators'
+
+// Trim string fields. Mutates a shallow copy.
+function trimStringFields(obj, keys) {
+  const out = { ...obj }
+  for (const k of keys) {
+    if (typeof out[k] === 'string') out[k] = out[k].trim()
+  }
+  return out
+}
+
+// Full-payload validation (used by createCustomer).
+function normalizeCustomerCreate(payload) {
+  const clean = trimStringFields(payload, ['name', 'phone', 'email', 'notes', 'agent'])
+  const errors = validateCustomerForm(clean)
+  if (errors) throw new ValidationError(errors)
+  return clean
+}
+
+// Partial-payload validation (used by updateCustomer). Only fields present in
+// the patch are checked; the "at least one contact" rule is enforced by the
+// DB CHECK rather than re-derived here (the patch may not include all three).
+function normalizeCustomerUpdate(payload) {
+  const clean = trimStringFields(payload, ['name', 'phone', 'email', 'notes', 'agent'])
+  const errors = {}
+  if ('name' in clean) {
+    const e = validateRequired(clean.name, 'Name')
+      ?? validateMaxLength(clean.name, LIMITS.name.max, 'Name')
+    if (e) errors.name = e
+  }
+  if ('phone' in clean) {
+    const e = validatePhone(clean.phone)
+    if (e) errors.phone = e
+  }
+  if ('email' in clean) {
+    const e = validateEmail(clean.email)
+    if (e) errors.email = e
+  }
+  if ('telegramChatId' in clean) {
+    const e = validateTelegramChatId(clean.telegramChatId)
+    if (e) errors.telegramChatId = e
+  }
+  if ('agent' in clean) {
+    const e = validateMaxLength(clean.agent, LIMITS.agent.max, 'Agent')
+    if (e) errors.agent = e
+  }
+  if ('notes' in clean) {
+    const e = validateMaxLength(clean.notes, LIMITS.notes.max, 'Notes')
+    if (e) errors.notes = e
+  }
+  if (Object.keys(errors).length) throw new ValidationError(errors)
+  return clean
+}
 
 function mapRowToCustomer(row) {
   return {
@@ -55,14 +118,16 @@ export async function getCustomer(id) {
 }
 
 export async function createCustomer(payload) {
-  const row = mapCustomerToRow(payload)
+  const clean = normalizeCustomerCreate(payload)
+  const row = mapCustomerToRow(clean)
   const { data, error } = await supabase.from('customers').insert(row).select().single()
   if (error) throw error
   return mapRowToCustomer(data)
 }
 
 export async function updateCustomer(id, payload) {
-  const row = mapCustomerToRow(payload)
+  const clean = normalizeCustomerUpdate(payload)
+  const row = mapCustomerToRow(clean)
   const { data, error } = await supabase
     .from('customers')
     .update(row)
@@ -135,6 +200,9 @@ export async function listFeedback(customerId) {
 
 export async function addFeedback(customerId, input) {
   const { note, type, durationMinutes } = normalizeFeedbackPayload(input)
+  // Final safety check: enforce note length + duration/type coupling
+  const errors = validateFeedback({ note, type, durationMinutes })
+  if (errors) throw new ValidationError(errors)
   const { data, error } = await supabase
     .from('customer_feedback')
     .insert({

--- a/Bold_Vision_CRM/src/services/mediaService.js
+++ b/Bold_Vision_CRM/src/services/mediaService.js
@@ -1,4 +1,5 @@
 import { supabase } from './supabase'
+import { validatePhotoFile, ValidationError } from '../utils/validators'
 
 const BUCKET = { photo: 'property-photos', floorplan: 'property-floorplans' }
 const SIGNED_URL_TTL = 3600
@@ -8,6 +9,11 @@ const SIGNED_URL_TTL = 3600
 const urlCache = new Map()
 
 export async function uploadPropertyImage(propertyId, file, { kind = 'photo' } = {}) {
+  // Service-layer guard: callers can bypass the UI (devtools, programmatic
+  // upload) — enforce size/type here too. Bucket policy is the final net.
+  const err = validatePhotoFile(file)
+  if (err) throw new ValidationError({ file: err })
+
   const { data: { user } } = await supabase.auth.getUser()
   const ext = file.name.split('.').pop()
   const path = `${user.id}/${propertyId}/${Date.now()}.${ext}`

--- a/Bold_Vision_CRM/src/services/messagesService.js
+++ b/Bold_Vision_CRM/src/services/messagesService.js
@@ -1,81 +1,136 @@
 import { supabase } from './supabase'
 import { getPropertyMediaSignedUrls } from './mediaService'
+import {
+  validateRequired,
+  validateMaxLength,
+  LIMITS,
+  ValidationError,
+} from '../utils/validators'
 
 const TELEGRAM_CAPTION_LIMIT = 1024  // hard limit on caption length per Telegram API
 
-export async function createBroadcast({ propertyId, body, audienceFilter, customers, includeMedia = false }) {
-  const recipientCustomers = customers.filter((c) => c.telegramChatId)
+// ─────────────────────────────────────────────────────────────────────────────
+// createBroadcast — Phase 8 Slice 2 contract
+//
+// What the client sends:
+//   - propertyId
+//   - body
+//   - audienceFilter ('All' | 'Hot' | 'Warm' | 'Cold')
+//   - includeMedia
+//   - idempotencyKey  (optional — caller pins it across retries; auto-gen if absent)
+//
+// What the client does NOT send anymore (vs Slice 1 / Phase 6):
+//   - recipients list  → the edge fn derives it from audienceFilter via RLS
+//   - per-recipient telegramChatId / body in the invoke payload  → server-derived
+//
+// Why: audit C11 — a tampered client could previously insert message_recipients
+// rows for any customer they own regardless of audience filter. With the new
+// flow, audience_filter on the message is the only knob; the edge fn does the
+// customer query under the caller's JWT.
+//
+// Idempotency (audit C10): if the same idempotencyKey is submitted twice, the
+// second insert collides (UNIQUE on `messages (auth_user_id, idempotency_key)`
+// from migration 0013). We catch the 23505, look up the existing message, and
+// invoke the edge fn with that id — it follows the retry path and only resends
+// previously-failed recipients.
+// ─────────────────────────────────────────────────────────────────────────────
+export async function createBroadcast({
+  propertyId,
+  body,
+  audienceFilter,
+  includeMedia = false,
+  idempotencyKey,
+}) {
+  // 1) Client-side pre-flight (defense in depth — edge fn re-validates).
+  //    Recipient gate is BroadcastPanel's job (it has the live count); here we
+  //    just validate the body length.
+  const bodyErr = validateRequired(body, 'Message')
+    ?? validateMaxLength(body, LIMITS.messageBody.max, 'Message')
+  if (bodyErr) throw new ValidationError({ body: bodyErr })
 
-  // 1) Optionally build the media album (signed URLs the edge fn forwards
-  //    to Telegram's sendMediaGroup). Same URLs reused for all recipients.
+  // 2) Stable idempotency key. If the caller didn't pin one, generate now —
+  //    a single createBroadcast invocation is one logical broadcast.
+  const key = idempotencyKey ?? crypto.randomUUID()
+
+  // 3) Optionally build the signed media URLs the edge fn forwards to
+  //    Telegram's sendMediaGroup. Failure → fall back to text-only.
   let mediaUrls = []
   if (includeMedia && propertyId) {
     try {
       mediaUrls = await getPropertyMediaSignedUrls(propertyId, 10)
     } catch (e) {
-      // Don't block the broadcast on a media-fetch failure — fall back to text.
       console.warn('Failed to build media URLs, sending text-only:', e)
       mediaUrls = []
     }
   }
   const willSendMedia = mediaUrls.length > 0
 
-  // 2) Create the message record
-  const { data: message, error: msgError } = await supabase
+  // 4) Insert the message row. Most calls are first-time; the catch handles
+  //    the rare retry case where the same idempotency_key was already inserted.
+  let message
+  const { data: inserted, error: msgError } = await supabase
     .from('messages')
     .insert({
       property_id: propertyId || null,
       body,
       channel: 'Telegram',
       audience_filter: audienceFilter,
-      recipient_count: recipientCustomers.length,
+      // recipient_count is backfilled by the edge fn after it derives the
+      // audience. Default 0 so the column is never null.
+      recipient_count: 0,
       includes_media: willSendMedia,
+      idempotency_key: key,
     })
     .select()
     .single()
 
-  if (msgError) throw msgError
-
-  if (recipientCustomers.length === 0) {
-    return { ok: true, sent: 0, failed: 0, results: [] }
+  if (msgError) {
+    // 23505 = unique_violation. We've already inserted a message with this
+    // idempotency_key for this agent — it's a retry. Look it up and reuse.
+    if (msgError.code === '23505') {
+      const { data: existing, error: lookupErr } = await supabase
+        .from('messages')
+        .select('id')
+        .eq('idempotency_key', key)
+        .maybeSingle()
+      if (lookupErr || !existing) {
+        throw lookupErr ?? new Error('idempotency collision but lookup returned no row')
+      }
+      message = existing
+    } else {
+      throw msgError
+    }
+  } else {
+    message = inserted
   }
 
-  // 3) Create queued recipient rows
-  const { data: recipients, error: recipError } = await supabase
-    .from('message_recipients')
-    .insert(
-      recipientCustomers.map((c) => ({
-        message_id: message.id,
-        customer_id: c.id,
-        telegram_chat_id: c.telegramChatId,
-        status: 'queued',
-      })),
-    )
-    .select()
-
-  if (recipError) throw recipError
-
-  // 4) Invoke edge function — sends messages and updates statuses
+  // 5) Invoke the edge function. The fn derives recipients server-side (first
+  //    call) or resends previously-failed ones (retry call) — the client
+  //    payload is the same either way.
   const { data: result, error: fnError } = await supabase.functions.invoke('send-telegram', {
     body: {
       messageId: message.id,
-      recipients: recipients.map((r) => ({
-        recipientId: r.id,
-        customerId: r.customer_id,
-        telegramChatId: r.telegram_chat_id,
-        body,
-      })),
-      mediaUrls,                              // shared across all recipients
+      mediaUrls,                          // shared across all recipients
       captionLimit: TELEGRAM_CAPTION_LIMIT,
     },
   })
 
   if (fnError) throw fnError
+  if (result && result.ok === false) {
+    // Edge fn returned a structured error code (auth / not_found /
+    // recipient_cap / internal etc.). Surface it as a thrown error so the
+    // BroadcastPanel toast catches it.
+    throw new Error(result.error || 'Broadcast failed')
+  }
 
-  const sent   = result.results?.filter((r) => r.status === 'sent').length  ?? 0
-  const failed = result.results?.filter((r) => r.status === 'failed').length ?? 0
-
-  return { ok: true, sent, failed, results: result.results ?? [], includedMedia: willSendMedia }
+  return {
+    ok: true,
+    sent:           result?.sent   ?? 0,
+    failed:         result?.failed ?? 0,
+    results:        result?.results ?? [],
+    includedMedia:  willSendMedia,
+    idempotencyKey: key,
+  }
 }
 
 export async function listBroadcastsForProperty(propertyId) {

--- a/Bold_Vision_CRM/src/services/propertiesService.js
+++ b/Bold_Vision_CRM/src/services/propertiesService.js
@@ -1,8 +1,30 @@
 import { supabase } from './supabase'
 import { computeBadge } from '../utils/property'
 import { formatSqm, parsePriceGuideString } from '../utils/formatters'
+import { validatePropertyForm, ValidationError } from '../utils/validators'
 
 const DAY_MS = 24 * 60 * 60 * 1000
+
+function trimStringFields(obj, keys) {
+  const out = { ...obj }
+  for (const k of keys) {
+    if (typeof out[k] === 'string') out[k] = out[k].trim()
+  }
+  return out
+}
+
+const TEXT_FIELDS = [
+  'address', 'suburb', 'state', 'postcode', 'type', 'status',
+  'priceGuide', 'description', 'notes', 'code',
+  'agentName', 'agentPhone', 'agentEmail',
+]
+
+function normalizePropertyPayload(payload) {
+  const clean = trimStringFields(payload, TEXT_FIELDS)
+  const errors = validatePropertyForm(clean)
+  if (errors) throw new ValidationError(errors)
+  return clean
+}
 
 function mapRowToProperty(row) {
   const listedAt = row.listed_at
@@ -124,14 +146,16 @@ export async function getProperty(id) {
 }
 
 export async function createProperty(payload) {
-  const row = mapPropertyToRow(payload)
+  const clean = normalizePropertyPayload(payload)
+  const row = mapPropertyToRow(clean)
   const { data, error } = await supabase.from('properties').insert(row).select().single()
   if (error) throw error
   return mapRowToProperty(data)
 }
 
 export async function updateProperty(id, payload) {
-  const row = mapPropertyToRow(payload)
+  const clean = normalizePropertyPayload(payload)
+  const row = mapPropertyToRow(clean)
   const { data, error } = await supabase
     .from('properties')
     .update(row)

--- a/Bold_Vision_CRM/src/stores/assessmentStore.js
+++ b/Bold_Vision_CRM/src/stores/assessmentStore.js
@@ -6,6 +6,20 @@ import {
   updateMeta as updateMetaService,
   submitAssessment,
 } from '../services/assessmentsService'
+import { ValidationError } from '../utils/validators'
+import { useFeedback } from '../composables/useFeedback'
+
+// Show validation errors as a focused toast; surface other errors via the
+// generic prefix. Returns void.
+function reportAutosaveError(err, sectionLabel) {
+  const { notifyError, notifyFromError } = useFeedback()
+  if (err instanceof ValidationError) {
+    const msg = err.firstMessage ?? err.message
+    notifyError(`${sectionLabel}: ${msg}`)
+  } else {
+    notifyFromError(err, `Couldn't save ${sectionLabel}`)
+  }
+}
 
 const SECTION_DEBOUNCE_MS = 1000
 
@@ -104,6 +118,7 @@ export const useAssessmentStore = defineStore('assessments', {
           this.byCustomer[customerId] = updated
         } catch (e) {
           this.error = e.message
+          reportAutosaveError(e, sectionKey)
         } finally {
           this.saving = false
         }
@@ -128,6 +143,7 @@ export const useAssessmentStore = defineStore('assessments', {
           this.byCustomer[customerId] = updated
         } catch (e) {
           this.error = e.message
+          reportAutosaveError(e, 'meta')
         } finally {
           this.saving = false
         }
@@ -172,6 +188,7 @@ export const useAssessmentStore = defineStore('assessments', {
             }
           } catch (e) {
             this.error = e.message
+            reportAutosaveError(e, sectionKey === '__meta' ? 'meta' : sectionKey)
           } finally {
             this.saving = false
           }

--- a/Bold_Vision_CRM/src/stores/authStore.js
+++ b/Bold_Vision_CRM/src/stores/authStore.js
@@ -8,14 +8,32 @@ export const useAuthStore = defineStore('auth', {
     user: null,
     session: null,
     loading: true,
+    // C8: set when init() fails (e.g. Supabase unreachable). LoginView surfaces
+    // it so the user knows it's a connectivity issue, not bad credentials.
+    initError: null,
   }),
 
   actions: {
+    // Called once at app boot from main.js, BEFORE mount (C12). Resolves the
+    // session synchronously from the app's perspective so the router guard
+    // can read `session` without re-querying. Never throws — errors surface
+    // via `initError`. The onAuthChange listener wires up the long-lived
+    // subscription for future sign-in / sign-out / token-refresh events.
     async init() {
       this.loading = true
-      this.session = await getSession()
-      this.user = this.session?.user ?? null
-      this.loading = false
+      this.initError = null
+      try {
+        this.session = await getSession()
+        this.user = this.session?.user ?? null
+      } catch (e) {
+        // Auth service unreachable. Stay logged out; surface to LoginView.
+        this.session = null
+        this.user = null
+        this.initError = e?.message || 'Could not reach the authentication service. Check your connection and try again.'
+        console.error('authStore.init() failed:', e)
+      } finally {
+        this.loading = false
+      }
 
       if (this.session) {
         usePropertyStore().fetchProperties()

--- a/Bold_Vision_CRM/src/styles/components/assessment-form.css
+++ b/Bold_Vision_CRM/src/styles/components/assessment-form.css
@@ -78,6 +78,18 @@
   background: var(--success);
   color: var(--text-on-accent, white);
 }
+/* In-progress: section has been touched but at least one required-or-tracked
+   field is blank-without-N/A. Amber dot replaces the number. */
+.afm-nav a.is-progress .step {
+  background: var(--warm-soft, color-mix(in oklab, #f6a821 22%, transparent));
+  color: var(--warm-ink, #b87410);
+}
+.afm-nav-dot {
+  width: 8px; height: 8px;
+  border-radius: 50%;
+  background: var(--warm-ink, #b87410);
+  display: inline-block;
+}
 
 .afm-progress {
   margin-top: 12px; padding: 8px 12px;
@@ -394,4 +406,81 @@
     margin-bottom: 8px;
   }
   .afm-actionbar { margin: 0 -12px -24px -12px; padding: 12px; }
+}
+
+/* ─── N/A toggle button (Slice 1b) ───
+   Tiny pill placed next to optional fields. Inactive: ghost outline. Active:
+   filled muted accent — the input next to it is disabled and visibly greyed
+   so the agent sees at a glance which fields were intentionally skipped. */
+.afm-na-btn {
+  display: inline-grid; place-items: center;
+  height: 22px;
+  padding: 0 8px;
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  color: var(--text-faint);
+  font-size: 10.5px;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  cursor: pointer;
+  transition: background .12s, color .12s, border-color .12s;
+  flex-shrink: 0;
+  user-select: none;
+}
+.afm-na-btn:hover {
+  color: var(--text);
+  border-color: var(--border-strong);
+}
+.afm-na-btn.is-active {
+  background: var(--accent-soft);
+  color: var(--accent-ink);
+  border-color: transparent;
+}
+.afm-na-btn.is-active:hover {
+  background: color-mix(in oklab, var(--accent-soft) 70%, var(--accent) 30%);
+}
+
+/* When a field is N/A'd, the input itself goes muted so the agent can see at
+   a glance which lines were skipped. Apply via .afm-na-on on a wrapper. */
+.afm-na-on .input,
+.afm-na-on .select,
+.afm-na-on .textarea {
+  opacity: 0.45;
+  pointer-events: none;
+  background: var(--surface-sunk);
+}
+.afm-na-on .seg-control {
+  opacity: 0.45;
+  pointer-events: none;
+}
+
+/* Field + N/A button layout helper: places the button after the input on a
+   single line. Sections drop this around any (input, NAButton) pair. */
+.afm-field-with-na {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+.afm-field-with-na > :first-child { flex: 1; min-width: 0; }
+
+/* Section-header N/A toggle (Liabilities "No liabilities to record"). Larger
+   than the inline pill, sits in the section head's right slot. */
+.afm-section-na {
+  display: inline-flex; align-items: center; gap: 8px;
+  padding: 8px 14px;
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  font-size: 12.5px; font-weight: 600;
+  color: var(--text-muted);
+  cursor: pointer;
+  user-select: none;
+}
+.afm-section-na input[type="checkbox"] { cursor: pointer; }
+.afm-section-na.is-active {
+  background: var(--accent-soft);
+  border-color: transparent;
+  color: var(--accent-ink);
 }

--- a/Bold_Vision_CRM/src/styles/tokens.css
+++ b/Bold_Vision_CRM/src/styles/tokens.css
@@ -195,6 +195,47 @@
   cursor: pointer;
 }
 
+/* Validation error state — set .is-error on the parent .field */
+.field.is-error .input,
+.field.is-error .textarea,
+.field.is-error .select {
+  border-color: var(--danger, oklch(56% 0.20 27));
+  background: oklch(96% 0.03 27);
+}
+:root[data-theme="dark"] .field.is-error .input,
+:root[data-theme="dark"] .field.is-error .textarea,
+:root[data-theme="dark"] .field.is-error .select {
+  background: oklch(28% 0.06 27);
+}
+.field.is-error .input:focus,
+.field.is-error .textarea:focus,
+.field.is-error .select:focus {
+  box-shadow: 0 0 0 3px oklch(56% 0.20 27 / 0.18);
+}
+.field-error {
+  margin: 4px 0 0;
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--danger, oklch(56% 0.20 27));
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+.form-error {
+  margin: 8px 0 0;
+  padding: 8px 12px;
+  font-size: 12.5px;
+  font-weight: 500;
+  color: var(--danger, oklch(56% 0.20 27));
+  background: oklch(96% 0.03 27);
+  border: 1px solid oklch(80% 0.10 27);
+  border-radius: var(--r-md);
+}
+:root[data-theme="dark"] .form-error {
+  background: oklch(28% 0.06 27);
+  border-color: oklch(40% 0.10 27);
+}
+
 /* Input wrapper with prefix/suffix overlays */
 .input-affix { position: relative; display: flex; align-items: center; }
 .input-affix .prefix,

--- a/Bold_Vision_CRM/src/utils/followUp.js
+++ b/Bold_Vision_CRM/src/utils/followUp.js
@@ -14,22 +14,32 @@ export function cadenceLabel(category) {
 // ── Status ─────────────────────────────────────────────────────────────────
 
 // Returns one of: 'never-contacted' | 'unscheduled' | 'overdue' | 'approaching' | 'up-to-date'
+//
+// "Overdue" is now any time strictly in the past, including a few hours ago
+// today — not just past calendar days. So a card scheduled for 9am that the
+// agent looks at at 5pm correctly shows as overdue.
 export function customerStatus(customer, today = new Date()) {
   if (!customer.nextContactAt) {
     return customer.lastContactedAt ? 'unscheduled' : 'never-contacted'
   }
   const next = new Date(customer.nextContactAt)
+  if (next < today) return 'overdue'
   const diffDays = Math.ceil((next - today) / (1000 * 60 * 60 * 24))
-  if (diffDays < 0) return 'overdue'
   if (diffDays <= 30) return 'approaching'
   return 'up-to-date'
 }
 
 // Days until next contact (negative = past due). null if no schedule set.
+//
+// Past times round DOWN (Math.floor) so "scheduled 8 hours ago" → -1 day,
+// showing as "1d overdue" instead of 0.
+// Future times round UP (Math.ceil) preserves the existing "Due in N days"
+// display behavior.
 export function daysUntilContact(customer, today = new Date()) {
   if (!customer.nextContactAt) return null
   const next = new Date(customer.nextContactAt)
-  return Math.ceil((next - today) / (1000 * 60 * 60 * 24))
+  const diff = (next - today) / (1000 * 60 * 60 * 24)
+  return diff < 0 ? Math.floor(diff) : Math.ceil(diff)
 }
 
 export function isOverdue(customer, today = new Date()) {
@@ -95,7 +105,9 @@ export function bucketCustomersForWeek(customers, today = new Date(), weekOffset
       continue
     }
     const next = new Date(c.nextContactAt)
-    if (next < todayStart) {
+    // Overdue = strictly before NOW (not midnight today) — a card scheduled
+    // today at 9am is overdue when the agent looks at the board at 5pm.
+    if (next < today) {
       overdue.push(c)
     } else if (next >= viewStart && next < viewEnd) {
       const bucket = days.find((d) => isSameDay(d.date, next))

--- a/Bold_Vision_CRM/src/utils/formatters.js
+++ b/Bold_Vision_CRM/src/utils/formatters.js
@@ -32,14 +32,23 @@ export function formatPrice(min, max) {
 }
 
 // Parse flexible user input ("1m", "1.5M", "850k", "$1,000,000", "1000000")
-// into a number. Returns null when unparseable.
+// into a number. Returns null when unparseable. Hardened for copy-paste edge
+// cases — strips NBSP / zero-width spaces, ignores leading "+", rejects
+// negative and scientific notation.
 export function parsePriceInput(raw) {
   if (raw == null) return null
-  const cleaned = String(raw).trim().replace(/[$,\s]/g, '').toLowerCase()
+  // \s covers ASCII whitespace; the extras are NBSP + zero-width chars that
+  // commonly sneak in when pasting from Word / web.
+  const cleaned = String(raw)
+    .trim()
+    .replace(/^\+/, '')
+    .replace(/[$,\s ​‌‍﻿]/g, '')
+    .toLowerCase()
   if (!cleaned) return null
   const m = cleaned.match(/^(\d+(?:\.\d+)?)([mk]?)$/)
   if (!m) return null
   const num = parseFloat(m[1])
+  if (!Number.isFinite(num)) return null
   if (m[2] === 'm') return Math.round(num * 1_000_000)
   if (m[2] === 'k') return Math.round(num * 1_000)
   return Math.round(num)

--- a/Bold_Vision_CRM/src/utils/inputFilters.js
+++ b/Bold_Vision_CRM/src/utils/inputFilters.js
@@ -1,0 +1,81 @@
+// Keystroke-level input filters. Used on @keydown to block invalid characters
+// before they appear in the field — gives the agent immediate feedback rather
+// than a delayed validation error. Each helper also exposes a `sanitize()`
+// counterpart for paste / autofill paths.
+//
+// Pattern:
+//   <input @keydown="currencyKeydown" @input="onCurrencyInput($event, update)" />
+//
+// where `update` is the model setter (e.g. `(v) => patch('client1', { rentAmount: v })`).
+
+// ── Currency: digits, decimal point, comma, dollar sign, space, k/m suffix ──
+
+const CURRENCY_ALLOWED = /^[0-9.,$ kmKM]$/
+
+// Allow navigation keys + ctrl/cmd combos to pass through (copy/paste/select-all).
+const PASSTHROUGH = new Set([
+  'Backspace', 'Delete', 'Tab', 'Enter', 'Escape', 'Home', 'End',
+  'ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown',
+])
+
+export function currencyKeydown(e) {
+  if (PASSTHROUGH.has(e.key)) return
+  if (e.ctrlKey || e.metaKey || e.altKey) return
+  if (e.key.length !== 1) return  // function keys, etc.
+  if (!CURRENCY_ALLOWED.test(e.key)) e.preventDefault()
+}
+
+export function currencySanitize(value) {
+  return String(value ?? '').replace(/[^0-9.,$ kmKM]/g, '')
+}
+
+// ── Integer: digits only ────────────────────────────────────────────────────
+
+const INT_ALLOWED = /^[0-9]$/
+
+export function integerKeydown(e) {
+  if (PASSTHROUGH.has(e.key)) return
+  if (e.ctrlKey || e.metaKey || e.altKey) return
+  if (e.key.length !== 1) return
+  if (!INT_ALLOWED.test(e.key)) e.preventDefault()
+}
+
+export function integerSanitize(value) {
+  return String(value ?? '').replace(/\D/g, '')
+}
+
+// ── Decimal: digits + at most one decimal point ─────────────────────────────
+
+export function decimalKeydown(e) {
+  if (PASSTHROUGH.has(e.key)) return
+  if (e.ctrlKey || e.metaKey || e.altKey) return
+  if (e.key.length !== 1) return
+  // Only digits and a single dot (already present? block another)
+  if (e.key === '.') {
+    if (String(e.target.value || '').includes('.')) e.preventDefault()
+    return
+  }
+  if (!/^[0-9]$/.test(e.key)) e.preventDefault()
+}
+
+export function decimalSanitize(value) {
+  const s = String(value ?? '').replace(/[^0-9.]/g, '')
+  const firstDot = s.indexOf('.')
+  if (firstDot === -1) return s
+  return s.slice(0, firstDot + 1) + s.slice(firstDot + 1).replace(/\./g, '')
+}
+
+// ── Date-ish text (MM/YYYY) — digits and slash only ─────────────────────────
+
+const DATE_PARTIAL = /^[0-9/]$/
+
+export function dateTextKeydown(e) {
+  if (PASSTHROUGH.has(e.key)) return
+  if (e.ctrlKey || e.metaKey || e.altKey) return
+  if (e.key.length !== 1) return
+  if (!DATE_PARTIAL.test(e.key)) e.preventDefault()
+}
+
+export function dateTextSanitize(value) {
+  return String(value ?? '').replace(/[^0-9/]/g, '')
+}

--- a/Bold_Vision_CRM/src/utils/validators.js
+++ b/Bold_Vision_CRM/src/utils/validators.js
@@ -1,0 +1,672 @@
+// Shared validators used by forms (inline error display) and services (throw
+// before DB write). Each validator returns null on success or an error string
+// on failure. Composite validators return { field: errorString } or null.
+//
+// Defense in depth: forms call these on @blur + on save click; services call
+// the composite validator and throw ValidationError if any field fails; the
+// DB has matching CHECK constraints as the last line.
+
+import { parsePriceInput } from './formatters'
+
+// ── Error type ──────────────────────────────────────────────────────────────
+
+export class ValidationError extends Error {
+  constructor(errors, message = 'Validation failed') {
+    super(message)
+    this.name = 'ValidationError'
+    // `errors` is either { field: msg, ... } for composite or a single string
+    this.errors = typeof errors === 'string' ? { _: errors } : errors
+    // Convenience for toast display: first error message
+    this.field = Object.keys(this.errors)[0] ?? null
+    this.firstMessage = this.field ? this.errors[this.field] : message
+  }
+}
+
+// ── Constants ───────────────────────────────────────────────────────────────
+
+const EMAIL_RE  = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+const PHONE_RE  = /^[+\d\s\-()]{6,20}$/
+const AU_POST_RE = /^\d{4}$/
+const TG_CHAT_RE = /^-?\d{6,16}$/
+
+// Sane outer bounds. Anything beyond these is almost certainly bad input.
+export const LIMITS = Object.freeze({
+  name:           { min: 1, max: 100 },
+  email:          { max: 254 },
+  phone:          { min: 6, max: 20 },
+  notes:          { max: 5000 },
+  agent:          { max: 100 },
+  address:        { min: 1, max: 200 },
+  suburb:         { max: 100 },
+  description:    { max: 5000 },
+  propertyCode:   { max: 50 },
+  bedrooms:       { max: 50 },
+  bathrooms:      { max: 50 },
+  carSpaces:      { max: 100 },
+  landSize:       { max: 1_000_000 },
+  houseSize:      { max: 100_000 },
+  priceMax:       { max: 999_000_000 },
+  messageBody:    { min: 1, max: 4096 },
+  recipientCap:   { max: 200 },
+  callDuration:   { max: 600 },
+  assessmentCurrency: { max: 99_000_000 },
+  budgetCurrency:     { max: 999_000_000 },
+  liabilityRowCap:    { max: 50 },
+  assessmentText:     { max: 100 },
+  assessmentLongText: { max: 1000 },
+  assessmentNote:     { max: 5000 },
+  photoSizeBytes:     { max: 10 * 1024 * 1024 },
+  photoBatch:         { max: 20 },
+})
+
+const PHOTO_MIME = new Set(['image/jpeg', 'image/png', 'image/webp'])
+
+// ── Atomic validators ───────────────────────────────────────────────────────
+
+export function validateRequired(value, label = 'Field') {
+  if (value === null || value === undefined) return `${label} is required`
+  if (typeof value === 'string' && value.trim() === '') return `${label} is required`
+  return null
+}
+
+export function validateMaxLength(value, max, label = 'Field') {
+  if (value == null || value === '') return null
+  if (String(value).length > max) return `${label} must be ${max} characters or fewer`
+  return null
+}
+
+export function validateMinLength(value, min, label = 'Field') {
+  if (value == null || value === '') return null
+  if (String(value).trim().length < min) return `${label} must be at least ${min} characters`
+  return null
+}
+
+export function validateEmail(value) {
+  if (value == null || value === '') return null   // blank is allowed; caller enforces required separately
+  const v = String(value).trim()
+  if (v.length > LIMITS.email.max) return `Email must be ${LIMITS.email.max} characters or fewer`
+  if (!EMAIL_RE.test(v)) return 'Invalid email format'
+  return null
+}
+
+export function validatePhone(value) {
+  if (value == null || value === '') return null
+  const v = String(value).trim()
+  if (!PHONE_RE.test(v)) {
+    return 'Phone can only contain digits, +, spaces, dashes, parentheses (6–20 chars)'
+  }
+  return null
+}
+
+export function validatePostcode(value) {
+  if (value == null || value === '') return null
+  if (!AU_POST_RE.test(String(value).trim())) return 'Postcode must be 4 digits'
+  return null
+}
+
+export function validateTelegramChatId(value) {
+  if (value == null || value === '') return null
+  if (!TG_CHAT_RE.test(String(value).trim())) {
+    return 'Telegram chat ID must be 6–16 digits (optional leading −)'
+  }
+  return null
+}
+
+// Integer range. Empty/null/undefined are treated as 0 (callers can wrap with
+// validateRequired if blank is forbidden).
+export function validatePositiveInt(value, max, label = 'Field') {
+  if (value === '' || value === null || value === undefined) return null
+  const n = Number(value)
+  if (!Number.isFinite(n)) return `${label} must be a number`
+  if (!Number.isInteger(n)) return `${label} must be a whole number`
+  if (n < 0) return `${label} can't be negative`
+  if (n > max) return `${label} must be ${max} or less`
+  return null
+}
+
+export function validatePositiveNumber(value, max, label = 'Field') {
+  if (value === '' || value === null || value === undefined) return null
+  const n = Number(value)
+  if (!Number.isFinite(n)) return `${label} must be a number`
+  if (n < 0) return `${label} can't be negative`
+  if (n > max) return `${label} must be ${max.toLocaleString()} or less`
+  return null
+}
+
+export function validateDateNotInPast(value, label = 'Date') {
+  if (!value) return null
+  const t = Date.parse(value)
+  if (Number.isNaN(t)) return `${label} is not a valid date`
+  // Compare on day boundary in local TZ — being a few hours off today is fine
+  const now = new Date()
+  now.setHours(0, 0, 0, 0)
+  if (t < now.getTime()) return `${label} can't be in the past`
+  return null
+}
+
+export function validateDateMaxFuture(value, maxYears, label = 'Date') {
+  if (!value) return null
+  const t = Date.parse(value)
+  if (Number.isNaN(t)) return `${label} is not a valid date`
+  const cap = Date.now() + maxYears * 365 * 24 * 60 * 60 * 1000
+  if (t > cap) return `${label} can't be more than ${maxYears} year${maxYears === 1 ? '' : 's'} away`
+  return null
+}
+
+// ── Duplicate detection (phone / email) ─────────────────────────────────────
+
+// Reduce a phone string to digits-only so different formattings
+// ("0412 345 678", "+61412345678", "0412-345-678") compare equal.
+// Returns null for blank input.
+export function normalizePhone(value) {
+  if (value == null) return null
+  const digits = String(value).replace(/\D/g, '')
+  return digits.length ? digits : null
+}
+
+// Lower-case + trim email for case-insensitive comparison. Returns null for blank.
+export function normalizeEmail(value) {
+  if (value == null) return null
+  const v = String(value).trim().toLowerCase()
+  return v.length ? v : null
+}
+
+// Lower-case + trim name for case-insensitive comparison.
+function normalizeName(value) {
+  if (value == null) return null
+  const v = String(value).trim().toLowerCase()
+  return v.length ? v : null
+}
+
+// Given a candidate customer and a list of existing customers, return any that
+// match on normalized phone, email, or name. Excludes `excludeId` (used when
+// editing — don't flag the customer themselves).
+//
+// Returns { phone?: customer, email?: customer, name?: customer } — at most
+// one match per field. Phone/email are intended for hard block; name is a
+// soft warn (different people can share names legitimately).
+export function findDuplicateCustomers({ phone, email, name }, customers, { excludeId } = {}) {
+  const out = {}
+  const targetPhone = normalizePhone(phone)
+  const targetEmail = normalizeEmail(email)
+  const targetName  = normalizeName(name)
+  if (!targetPhone && !targetEmail && !targetName) return out
+
+  for (const c of customers || []) {
+    if (excludeId && c.id === excludeId) continue
+    if (!out.phone && targetPhone && normalizePhone(c.phone) === targetPhone) {
+      out.phone = c
+    }
+    if (!out.email && targetEmail && normalizeEmail(c.email) === targetEmail) {
+      out.email = c
+    }
+    if (!out.name && targetName && normalizeName(c.name) === targetName) {
+      out.name = c
+    }
+    if (out.phone && out.email && out.name) break
+  }
+  return out
+}
+
+// ── Currency parser (hardened wrapper around formatters.parsePriceInput) ────
+
+// Returns { value: number|null, error: string|null }. Single source of truth
+// for currency parsing across assessment + property forms.
+export function parseCurrency(raw, { max = LIMITS.priceMax.max, label = 'Amount' } = {}) {
+  if (raw == null || String(raw).trim() === '') return { value: null, error: null }
+  const n = parsePriceInput(raw)
+  if (n == null) return { value: null, error: `${label} is not a valid number` }
+  if (n < 0) return { value: null, error: `${label} can't be negative` }
+  if (n > max) return { value: null, error: `${label} must be ${max.toLocaleString()} or less` }
+  return { value: n, error: null }
+}
+
+// ── Composite validators (return { field: errMsg } or null) ─────────────────
+
+// Customer form: AddCustomerDialog + CustomerDetailView basic info.
+export function validateCustomerForm(form) {
+  const errors = {}
+  const nameErr = validateRequired(form.name, 'Name')
+    ?? validateMaxLength(form.name, LIMITS.name.max, 'Name')
+  if (nameErr) errors.name = nameErr
+
+  const phoneErr = validatePhone(form.phone)
+  if (phoneErr) errors.phone = phoneErr
+
+  const emailErr = validateEmail(form.email)
+  if (emailErr) errors.email = emailErr
+
+  const tgErr = validateTelegramChatId(form.telegramChatId)
+  if (tgErr) errors.telegramChatId = tgErr
+
+  const agentErr = validateMaxLength(form.agent, LIMITS.agent.max, 'Agent')
+  if (agentErr) errors.agent = agentErr
+
+  const notesErr = validateMaxLength(form.notes, LIMITS.notes.max, 'Notes')
+  if (notesErr) errors.notes = notesErr
+
+  // At-least-one-contact-method (form-level error)
+  const hasPhone = form.phone != null && String(form.phone).trim() !== ''
+  const hasEmail = form.email != null && String(form.email).trim() !== ''
+  const hasTg    = form.telegramChatId != null && String(form.telegramChatId).trim() !== ''
+  if (!hasPhone && !hasEmail && !hasTg) {
+    errors._ = 'At least one of phone, email, or Telegram chat ID is required'
+  }
+
+  return Object.keys(errors).length ? errors : null
+}
+
+// Property form: PropertiesForm (used by add + edit).
+export function validatePropertyForm(form) {
+  const errors = {}
+
+  const addrErr = validateRequired(form.address, 'Address')
+    ?? validateMaxLength(form.address, LIMITS.address.max, 'Address')
+  if (addrErr) errors.address = addrErr
+
+  const suburbErr = validateMaxLength(form.suburb, LIMITS.suburb.max, 'Suburb')
+  if (suburbErr) errors.suburb = suburbErr
+
+  const postErr = validatePostcode(form.postcode)
+  if (postErr) errors.postcode = postErr
+
+  const codeErr = validateMaxLength(form.code, LIMITS.propertyCode.max, 'Code')
+  if (codeErr) errors.code = codeErr
+
+  for (const [field, max, label] of [
+    ['bedrooms',  LIMITS.bedrooms.max,  'Bedrooms'],
+    ['bathrooms', LIMITS.bathrooms.max, 'Bathrooms'],
+    ['carSpaces', LIMITS.carSpaces.max, 'Car spaces'],
+    ['carparkSpaces', LIMITS.carSpaces.max, 'Carpark spaces'],
+  ]) {
+    const e = validatePositiveInt(form[field], max, label)
+    if (e) errors[field] = e
+  }
+
+  for (const [field, max, label] of [
+    ['landSizeSqm',  LIMITS.landSize.max,  'Land size'],
+    ['houseSizeSqm', LIMITS.houseSize.max, 'House size'],
+  ]) {
+    const e = validatePositiveNumber(form[field], max, label)
+    if (e) errors[field] = e
+  }
+
+  if (form.priceMin != null) {
+    const e = validatePositiveNumber(form.priceMin, LIMITS.priceMax.max, 'Price min')
+    if (e) errors.priceMin = e
+  }
+  if (form.priceMax != null) {
+    const e = validatePositiveNumber(form.priceMax, LIMITS.priceMax.max, 'Price max')
+    if (e) errors.priceMax = e
+  }
+  if (form.priceMin != null && form.priceMax != null
+      && Number(form.priceMax) < Number(form.priceMin)) {
+    errors.priceMax = 'Price max must be greater than or equal to Price min'
+  }
+
+  const descErr = validateMaxLength(form.description, LIMITS.description.max, 'Description')
+  if (descErr) errors.description = descErr
+
+  const notesErr = validateMaxLength(form.notes, LIMITS.notes.max, 'Notes')
+  if (notesErr) errors.notes = notesErr
+
+  if (form.agentEmail) {
+    const e = validateEmail(form.agentEmail)
+    if (e) errors.agentEmail = e
+  }
+  if (form.agentPhone) {
+    const e = validatePhone(form.agentPhone)
+    if (e) errors.agentPhone = e
+  }
+  const agentNameErr = validateMaxLength(form.agentName, LIMITS.agent.max, 'Agent name')
+  if (agentNameErr) errors.agentName = agentNameErr
+
+  return Object.keys(errors).length ? errors : null
+}
+
+// Broadcast: body + recipient list.
+export function validateBroadcast({ body, recipients }) {
+  const errors = {}
+  const bodyErr = validateRequired(body, 'Message')
+    ?? validateMaxLength(body, LIMITS.messageBody.max, 'Message')
+  if (bodyErr) errors.body = bodyErr
+
+  if (!Array.isArray(recipients) || recipients.length === 0) {
+    errors.recipients = 'No eligible recipients'
+  } else if (recipients.length > LIMITS.recipientCap.max) {
+    errors.recipients = `Too many recipients (max ${LIMITS.recipientCap.max} per broadcast)`
+  }
+  return Object.keys(errors).length ? errors : null
+}
+
+// Photo upload pre-checks.
+export function validatePhotoFile(file) {
+  if (!file) return 'No file'
+  if (!PHOTO_MIME.has(file.type)) return 'Only JPEG, PNG, or WebP images allowed'
+  if (file.size > LIMITS.photoSizeBytes.max) return 'File must be 10 MB or smaller'
+  return null
+}
+
+// Assessment section validator. Each section is loose-text by design (the
+// agent should be able to type "DD/MM/YYYY · Age" in a single field), so we
+// enforce length caps and parse currency rather than format-perfect input.
+//
+// N/A flags (Slice 1b): each section payload may carry an `na` map of fields
+// the agent has explicitly marked Not Applicable. For client-split sections
+// (personal/employment/income) it lives at `payload.client1.na = { rentAmount:
+// true, ... }`. For flat sections (assets/discovery/notes) it lives at
+// `payload.na = { vehicle2: true, ... }`. Liabilities has its own
+// `payload.naSection: true` (whole-section toggle).
+//
+// Print contract (deferred render layer, data ready today):
+//   - na[field] === true      → render literal "N/A"
+//   - value is non-empty      → render the value
+//   - otherwise (true blank)  → render "—" (signals agent left it blank
+//                                without an explicit decision)
+const ASSESSMENT_LIMITS = {
+  shortText:    LIMITS.assessmentText.max,    // 100
+  longText:     LIMITS.assessmentLongText.max, // 1000
+  noteText:     LIMITS.assessmentNote.max,    // 5000
+  currency:     LIMITS.assessmentCurrency.max, // 99M
+  budget:       LIMITS.budgetCurrency.max,    // 999M
+}
+
+// Reads `payload.na[key]` (flat sections) or `payload[side].na[key]`
+// (client-split sections). Returns true iff the field has been explicitly
+// marked Not Applicable. Used to skip validation on N/A'd fields.
+function isFieldNA(payload, key, side = null) {
+  if (!payload) return false
+  if (side) return payload[side]?.na?.[key] === true
+  return payload.na?.[key] === true
+}
+
+export function validateAssessmentSection(sectionKey, payload) {
+  if (payload == null || typeof payload !== 'object') return null
+  const errors = {}
+
+  const checkText = (val, key, max, label) => {
+    const e = validateMaxLength(val, max, label)
+    if (e) errors[key] = e
+  }
+  const checkCurrency = (val, key, max, label) => {
+    const { error } = parseCurrency(val, { max, label })
+    if (error) errors[key] = error
+  }
+
+  switch (sectionKey) {
+    case 'personal': {
+      for (const side of ['client1', 'client2']) {
+        const c = payload[side]
+        if (!c) continue
+        const naFor = (k) => isFieldNA(payload, k, side)
+        checkText(c.fullName,    `${side}.fullName`,    ASSESSMENT_LIMITS.shortText, 'Full name')
+        // Legacy single-field DOB (kept for back-compat). New split fields below.
+        if (!naFor('dobDate')) checkText(c.dob, `${side}.dob`, 30, 'DOB')
+        // Split DOB: dobDate (YYYY-MM-DD, not in future) + age (0–120)
+        if (!naFor('dobDate') && c.dobDate) {
+          const today = new Date().toISOString().slice(0, 10)
+          if (c.dobDate > today) errors[`${side}.dobDate`] = 'Date of birth can\'t be in the future'
+        }
+        if (!naFor('dobDate') && c.age !== undefined && c.age !== '' && c.age !== null) {
+          const ageErr = validatePositiveInt(c.age, 120, 'Age')
+          if (ageErr) errors[`${side}.age`] = ageErr
+        }
+        if (!naFor('dependants')) {
+          checkText(c.dependants, `${side}.dependants`, ASSESSMENT_LIMITS.shortText, 'Dependants')
+        }
+        // residencyOther only meaningful when residency === 'Other', but cap
+        // length whenever it has a value so stale values don't grow.
+        checkText(c.residencyOther, `${side}.residencyOther`, ASSESSMENT_LIMITS.shortText, 'Residency (specify)')
+        if (!naFor('address')) {
+          checkText(c.address, `${side}.address`, LIMITS.address.max, 'Address')
+        }
+        const phoneErr = validatePhone(c.phone); if (phoneErr) errors[`${side}.phone`] = phoneErr
+        if (!naFor('rentAmount')) {
+          checkCurrency(c.rentAmount, `${side}.rentAmount`, ASSESSMENT_LIMITS.currency, 'Rent')
+        }
+      }
+      break
+    }
+    case 'employment': {
+      for (const side of ['client1', 'client2']) {
+        const c = payload[side]
+        if (!c) continue
+        const naFor = (k) => isFieldNA(payload, k, side)
+        if (!naFor('occupation'))      checkText(c.occupation,      `${side}.occupation`,      ASSESSMENT_LIMITS.shortText, 'Occupation')
+        if (!naFor('employer'))        checkText(c.employer,        `${side}.employer`,        ASSESSMENT_LIMITS.shortText, 'Employer')
+        if (!naFor('previousJobNote')) checkText(c.previousJobNote, `${side}.previousJobNote`, ASSESSMENT_LIMITS.longText,  'Previous job notes')
+        // yearsInRole is now type=number (0–99, step 0.5)
+        if (!naFor('yearsInRole') && c.yearsInRole !== undefined && c.yearsInRole !== '' && c.yearsInRole !== null) {
+          const e = validatePositiveNumber(c.yearsInRole, 99, 'Years in role')
+          if (e) errors[`${side}.yearsInRole`] = e
+        }
+      }
+      break
+    }
+    case 'income': {
+      for (const side of ['client1', 'client2']) {
+        const c = payload[side]
+        if (!c) continue
+        const naFor = (k) => isFieldNA(payload, k, side)
+        for (const [rowKey, label] of [
+          ['salaryWages',    'Salary/Wages'],
+          ['bonus',          'Bonus'],
+          ['afterTax',       'After-tax pay'],
+          ['centrelink',     'Centrelink/DVA'],
+          ['investmentRent', 'Investment rent'],
+          ['other',          'Other income'],
+        ]) {
+          if (naFor(rowKey)) continue
+          const row = c[rowKey]
+          if (row && row.amount !== undefined) {
+            checkCurrency(row.amount, `${side}.${rowKey}.amount`, ASSESSMENT_LIMITS.currency, label)
+          }
+        }
+        // Free-text description for "Other (specify)" — only validate if not NA'd
+        if (!naFor('other') && c.other?.details !== undefined) {
+          checkText(c.other.details, `${side}.other.details`, 200, 'Other income — description')
+        }
+      }
+      break
+    }
+    case 'assets': {
+      for (const key of [
+        'principalResidence', 'homeContents', 'vehicle1', 'vehicle2',
+        'cashBankAccounts', 'futureSavings',
+        'investmentProperty1', 'investmentProperty2', 'investmentProperty3',
+        'otherLifestyle', 'directShares', 'managedFunds1', 'managedFunds2',
+        'superannuation1', 'superannuation2', 'otherAsset',
+      ]) {
+        if (isFieldNA(payload, key)) continue
+        if (payload[key] !== undefined) {
+          checkCurrency(payload[key], key, ASSESSMENT_LIMITS.currency, 'Asset value')
+        }
+      }
+      break
+    }
+    case 'liabilities': {
+      // Whole-section N/A skips row validation entirely.
+      if (payload.naSection === true) break
+      const rows = Array.isArray(payload.rows) ? payload.rows : []
+      if (rows.length > LIMITS.liabilityRowCap.max) {
+        errors.rows = `Too many liabilities (max ${LIMITS.liabilityRowCap.max})`
+      }
+      rows.forEach((row, i) => {
+        checkText(row.details, `rows[${i}].details`, ASSESSMENT_LIMITS.shortText, 'Details')
+        checkText(row.lender,  `rows[${i}].lender`,  ASSESSMENT_LIMITS.shortText, 'Lender')
+        checkText(row.remainingTerm, `rows[${i}].remainingTerm`, 20, 'Remaining term')
+        checkText(row.interestRate,  `rows[${i}].interestRate`,  10, 'Interest rate')
+        checkCurrency(row.value,     `rows[${i}].value`,     ASSESSMENT_LIMITS.currency, 'Outstanding')
+        checkCurrency(row.repayment, `rows[${i}].repayment`, ASSESSMENT_LIMITS.currency, 'Repayment')
+      })
+      break
+    }
+    case 'discovery': {
+      const naFor = (k) => isFieldNA(payload, k)
+      if (!naFor('q2_lookingDuration')) checkText(payload.q2_lookingDuration, 'q2_lookingDuration', LIMITS.address.max, 'Looking duration')
+      checkText(payload.q3_buyTimeline,     'q3_buyTimeline',     LIMITS.address.max, 'Buy timeline')
+      if (!naFor('q6_areaOfInterest'))  checkText(payload.q6_areaOfInterest,  'q6_areaOfInterest',  LIMITS.address.max, 'Area of interest')
+      if (!naFor('q8_propertyType'))    checkText(payload.q8_propertyType,    'q8_propertyType',    ASSESSMENT_LIMITS.shortText, 'Property type')
+      if (!naFor('q8b_minBedrooms') && payload.q8b_minBedrooms !== undefined && payload.q8b_minBedrooms !== '' && payload.q8b_minBedrooms !== null) {
+        const e = validatePositiveInt(payload.q8b_minBedrooms, 50, 'Min bedrooms')
+        if (e) errors.q8b_minBedrooms = e
+      }
+      if (!naFor('q10_landSize'))       checkText(payload.q10_landSize,       'q10_landSize',       ASSESSMENT_LIMITS.shortText, 'Land size')
+      if (!naFor('q11_landTitledDate')) checkText(payload.q11_landTitledDate, 'q11_landTitledDate', ASSESSMENT_LIMITS.shortText, 'Land titled date')
+      if (!naFor('q9_requirements'))    checkText(payload.q9_requirements,    'q9_requirements',    ASSESSMENT_LIMITS.longText,  'Requirements')
+      if (!naFor('q13_biggestConcern')) checkText(payload.q13_biggestConcern, 'q13_biggestConcern', ASSESSMENT_LIMITS.longText,  'Biggest concern')
+      if (!naFor('q7_budgetMin'))       checkCurrency(payload.q7_budgetMin,   'q7_budgetMin',   ASSESSMENT_LIMITS.budget,   'Budget min')
+      if (!naFor('q7_budgetMax'))       checkCurrency(payload.q7_budgetMax,   'q7_budgetMax',   ASSESSMENT_LIMITS.budget,   'Budget max')
+      if (!naFor('q14_depositAmount'))  checkCurrency(payload.q14_depositAmount, 'q14_depositAmount', ASSESSMENT_LIMITS.currency, 'Deposit')
+      break
+    }
+    case 'notes': {
+      const naFor = (k) => isFieldNA(payload, k)
+      checkText(payload.consultantName,    'consultantName',    ASSESSMENT_LIMITS.shortText, 'Consultant')
+      if (!naFor('brokerName'))        checkText(payload.brokerName,        'brokerName',        ASSESSMENT_LIMITS.shortText, 'Broker')
+      if (!naFor('preApprovalLender')) checkText(payload.preApprovalLender, 'preApprovalLender', ASSESSMENT_LIMITS.shortText, 'Pre-approval lender')
+      checkText(payload.consultantNotes,   'consultantNotes',   ASSESSMENT_LIMITS.noteText,  'Consultant notes')
+      if (!naFor('brokerNotes'))       checkText(payload.brokerNotes,       'brokerNotes',       ASSESSMENT_LIMITS.noteText,  'Broker notes')
+      if (!naFor('preApprovalAmount')) checkCurrency(payload.preApprovalAmount, 'preApprovalAmount', ASSESSMENT_LIMITS.currency, 'Pre-approval amount')
+      break
+    }
+    default:
+      // Unknown section keys are caught upstream in assessmentsService.updateSection
+      break
+  }
+
+  return Object.keys(errors).length ? errors : null
+}
+
+// ── Section completion (Slice 1b) ───────────────────────────────────────────
+//
+// Three-state nav rendering for the assessment form:
+//   - 'untouched'    → section not in touched_sections (handled by caller)
+//   - 'in-progress'  → touched but at least one optional field is blank-without-NA
+//   - 'complete'     → every optional field is either filled or explicitly N/A'd
+//
+// Caller uses touched_sections for untouched/in-progress split, then calls
+// `computeSectionStatus(sectionKey, assessment)` to distinguish in-progress
+// from complete.
+//
+// Why pass the whole `assessment` and not just the section payload? The Notes
+// section's `dateCompleted`, `consultantName`, `brokerName`, and
+// `nextAppointmentAt` live on top-level columns (mirrored from the customer or
+// stored separately), not in the notes JSONB. The N/A flags for those fields
+// still live in `notes.na` for consistency.
+
+function isFilledValue(v) {
+  if (v == null) return false
+  if (typeof v === 'string') return v.trim() !== ''
+  return true
+}
+
+// "Filled-or-N/A": the agent has made an explicit decision about this field —
+// either typed a value, or clicked the N/A button.
+function isFilledOrNA(value, naMap, key) {
+  if (naMap?.[key] === true) return true
+  return isFilledValue(value)
+}
+
+export function computeSectionStatus(sectionKey, assessment) {
+  if (!assessment) return 'in-progress'
+
+  switch (sectionKey) {
+    case 'personal': {
+      const c1 = assessment.personal?.client1 ?? {}
+      const na = c1.na ?? {}
+      // Optional client1 fields the agent should explicitly decide on
+      const fields = ['dobDate', 'dependants', 'address', 'rentAmount']
+      return fields.every((f) => isFilledOrNA(c1[f], na, f)) ? 'complete' : 'in-progress'
+    }
+    case 'employment': {
+      const c1 = assessment.employment?.client1 ?? {}
+      const na = c1.na ?? {}
+      const fields = ['occupation', 'employer', 'yearsInRole']
+      return fields.every((f) => isFilledOrNA(c1[f], na, f)) ? 'complete' : 'in-progress'
+    }
+    case 'income': {
+      const c1 = assessment.income?.client1 ?? {}
+      const na = c1.na ?? {}
+      const rows = ['salaryWages', 'bonus', 'afterTax', 'centrelink', 'investmentRent', 'other']
+      return rows.every((r) => {
+        if (na[r] === true) return true
+        return isFilledValue(c1[r]?.amount)
+      }) ? 'complete' : 'in-progress'
+    }
+    case 'assets': {
+      const payload = assessment.assets ?? {}
+      const na = payload.na ?? {}
+      const fields = [
+        'principalResidence', 'homeContents', 'vehicle1', 'vehicle2',
+        'cashBankAccounts', 'futureSavings',
+        'investmentProperty1', 'investmentProperty2', 'investmentProperty3',
+        'otherLifestyle', 'directShares', 'managedFunds1', 'managedFunds2',
+        'superannuation1', 'superannuation2', 'otherAsset',
+      ]
+      return fields.every((f) => isFilledOrNA(payload[f], na, f)) ? 'complete' : 'in-progress'
+    }
+    case 'liabilities': {
+      const payload = assessment.liabilities ?? {}
+      if (payload.naSection === true) return 'complete'
+      const rows = Array.isArray(payload.rows) ? payload.rows : []
+      return rows.length >= 1 ? 'complete' : 'in-progress'
+    }
+    case 'discovery': {
+      const payload = assessment.discovery ?? {}
+      const na = payload.na ?? {}
+      // Required (never N/A'able — seg-controls / picks)
+      const required = ['q1_contactedBroker', 'q3_buyTimeline', 'q5_purpose', 'q12_mostImportant']
+      const reqOk = required.every((f) => isFilledValue(payload[f]))
+      // Optional (N/A-eligible)
+      const optional = [
+        'q2_lookingDuration', 'q4_talkedBuildersAgents', 'q6_areaOfInterest',
+        'q7_budgetMin', 'q7_budgetMax', 'q8_propertyType', 'q8b_minBedrooms',
+        'q9_requirements', 'q10_landSize', 'q11_landTitledDate',
+        'q13_biggestConcern', 'q14_depositAmount',
+      ]
+      const optOk = optional.every((f) => isFilledOrNA(payload[f], na, f))
+      return reqOk && optOk ? 'complete' : 'in-progress'
+    }
+    case 'notes': {
+      const payload = assessment.notes ?? {}
+      const na = payload.na ?? {}
+      // Required: dateCompleted (top-level), consultantNotes (JSONB)
+      if (!isFilledValue(assessment.dateCompleted)) return 'in-progress'
+      if (!isFilledValue(payload.consultantNotes)) return 'in-progress'
+      // Optional: brokerName (top), preApprovalAmount/Lender + brokerNotes (JSONB),
+      // nextAppointmentAt (top)
+      const optionalChecks = [
+        ['brokerName',        assessment.brokerName],
+        ['preApprovalAmount', payload.preApprovalAmount],
+        ['preApprovalLender', payload.preApprovalLender],
+        ['brokerNotes',       payload.brokerNotes],
+        ['nextAppointmentAt', assessment.nextAppointmentAt],
+      ]
+      return optionalChecks.every(([k, v]) => na[k] === true || isFilledValue(v))
+        ? 'complete' : 'in-progress'
+    }
+    default:
+      return 'in-progress'
+  }
+}
+
+// Feedback entry (typed log activity).
+export function validateFeedback({ note, type, durationMinutes }) {
+  const errors = {}
+  const noteErr = validateRequired(note, 'Note')
+    ?? validateMaxLength(note, LIMITS.notes.max, 'Note')
+  if (noteErr) errors.note = noteErr
+
+  const VALID_TYPES = new Set(['call', 'email', 'sms', 'telegram', 'note'])
+  if (type && !VALID_TYPES.has(type)) errors.type = 'Invalid interaction type'
+
+  if (durationMinutes != null && durationMinutes !== '') {
+    if (type !== 'call') errors.durationMinutes = 'Duration only applies to calls'
+    else {
+      const e = validatePositiveInt(durationMinutes, LIMITS.callDuration.max, 'Duration')
+      if (e) errors.durationMinutes = e
+    }
+  }
+  return Object.keys(errors).length ? errors : null
+}

--- a/Bold_Vision_CRM/src/views/CustomerAssessmentView.vue
+++ b/Bold_Vision_CRM/src/views/CustomerAssessmentView.vue
@@ -11,11 +11,15 @@
         :key="s.id"
         :href="`#${s.id}`"
         :aria-current="active === s.id ? 'page' : undefined"
-        :class="{ 'is-complete': touched.has(s.id) }"
+        :class="{
+          'is-complete': sectionStatus(s.id) === 'complete',
+          'is-progress': sectionStatus(s.id) === 'in-progress',
+        }"
         @click.prevent="scrollTo(s.id)"
       >
         <span class="step">
-          <AppIcon v-if="touched.has(s.id)" name="check" :size="10" />
+          <AppIcon v-if="sectionStatus(s.id) === 'complete'" name="check" :size="10" />
+          <span v-else-if="sectionStatus(s.id) === 'in-progress'" class="afm-nav-dot"></span>
           <template v-else>{{ s.num }}</template>
         </span>
         <span>{{ s.title }}</span>
@@ -23,7 +27,7 @@
       <div class="afm-progress">
         <div style="display:flex;justify-content:space-between">
           <span>Progress</span>
-          <span style="font-variant-numeric:tabular-nums">{{ touched.size }}/{{ SECTIONS.length }}</span>
+          <span style="font-variant-numeric:tabular-nums">{{ completeCount }}/{{ SECTIONS.length }}</span>
         </div>
         <div class="bar"><i :style="{ width: progressPct + '%' }"></i></div>
       </div>
@@ -115,6 +119,8 @@ import { useRoute, useRouter, RouterLink } from 'vue-router'
 import { storeToRefs } from 'pinia'
 import { useCustomerStore } from '../stores/customerStore'
 import { useAssessmentStore } from '../stores/assessmentStore'
+import { useFeedback } from '../composables/useFeedback'
+import { computeSectionStatus } from '../utils/validators'
 import AppIcon from '../components/base/AppIcon.vue'
 import PersonalSection from '../components/assessment/PersonalSection.vue'
 import EmploymentSection from '../components/assessment/EmploymentSection.vue'
@@ -142,15 +148,46 @@ const id = computed(() => route.params.id)
 const customerStore = useCustomerStore()
 const assessmentStore = useAssessmentStore()
 const { saving } = storeToRefs(assessmentStore)
+const { notifyFromError } = useFeedback()
 
 const customer = computed(() =>
   customerStore.customers.find((c) => c.id === id.value) || null,
 )
 const assessment = computed(() => assessmentStore.forCustomer(id.value))
 
-// ─── Touched tracking + progress ───
+// ─── Touched tracking + completion ───
+// Three-state nav (Slice 1b):
+//   'untouched'   → section not yet in touched_sections
+//   'in-progress' → touched but at least one optional field blank-without-NA
+//   'complete'    → every optional field is filled or explicitly N/A'd
+// Progress bar denominator counts only `complete` sections.
 const touched = computed(() => new Set(assessment.value?.touchedSections ?? []))
-const progressPct = computed(() => Math.round((touched.value.size / SECTIONS.length) * 100))
+
+// `mergedForCompletion` overlays pending mirrored fields (name, agent,
+// nextContactAt) onto the assessment so completion picks them up immediately
+// without waiting for the 2.5s customer-store flush. Reads the latest pending
+// values where present, otherwise the canonical customer.
+const mergedForCompletion = computed(() => {
+  const a = assessment.value
+  if (!a) return null
+  return {
+    ...a,
+    consultantName: mirroredValue('agent', customer.value?.agent),
+    nextAppointmentAt: ('nextContactAt' in pendingMirrored.value)
+      ? pendingMirrored.value.nextContactAt
+      : (customer.value?.nextContactAt ?? null),
+  }
+})
+
+function sectionStatus(id) {
+  if (!touched.value.has(id)) return 'untouched'
+  return computeSectionStatus(id, mergedForCompletion.value)
+}
+
+const completeCount = computed(() =>
+  SECTIONS.filter((s) => sectionStatus(s.id) === 'complete').length,
+)
+const progressPct = computed(() => Math.round((completeCount.value / SECTIONS.length) * 100))
 
 // ─── Scroll spy (query sections by DOM id; works regardless of whether
 // the section is a placeholder or a real component) ───
@@ -205,7 +242,7 @@ onBeforeUnmount(() => {
 const autosaveLabel = computed(() => {
   if (!assessment.value) return 'Loading…'
   if (saving.value) return 'Saving…'
-  return `Autosaved · ${touched.value.size}/${SECTIONS.length} sections complete`
+  return `Autosaved · ${completeCount.value}/${SECTIONS.length} sections complete`
 })
 
 // ─── Relative start date ───
@@ -269,7 +306,10 @@ const metaForView = computed(() => ({
 }))
 
 // Per-field debounce for customer-store writes — pending state updates
-// immediately, network PATCH waits.
+// immediately, network PATCH waits 2.5s. The window is generous so an agent
+// who clears a field and retypes (clear → pause → type) doesn't trigger a
+// premature validation failure mid-edit.
+const MIRROR_DEBOUNCE_MS = 2500
 const customerWriteTimers = new Map()
 function debouncedCustomerWrite(field, value) {
   // 1) Instant display update
@@ -281,23 +321,31 @@ function debouncedCustomerWrite(field, value) {
   customerWriteTimers.set(field, setTimeout(async () => {
     customerWriteTimers.delete(field)
     const writeValue = value
+    let didError = false
     try {
       if (field === 'nextContactAt') {
         await customerStore.setNextContactAt(id.value, writeValue)
       } else {
         await customerStore.updateCustomer(id.value, { [field]: writeValue })
       }
+    } catch (e) {
+      // Validation failed (or network blew up). Surface to the agent and
+      // drop the pending value so the field snaps back to the canonical
+      // customer state instead of showing the rejected value.
+      didError = true
+      notifyFromError(e, `Couldn't save ${field}`)
     } finally {
-      // Only clear pending if no newer keystroke arrived (i.e. the pending
-      // value still matches what we just wrote). Otherwise leave it so the
-      // newer typing stays visible until its own timer flushes.
-      if (pendingMirrored.value[field] === writeValue) {
+      // Clear pending if:
+      //  - the write succeeded AND no newer keystroke arrived, OR
+      //  - the write errored (always — show the canonical value)
+      const stillCurrent = pendingMirrored.value[field] === writeValue
+      if (didError || stillCurrent) {
         const next = { ...pendingMirrored.value }
         delete next[field]
         pendingMirrored.value = next
       }
     }
-  }, 1000))
+  }, MIRROR_DEBOUNCE_MS))
 }
 
 function handlePersonalUpdate(updated) {

--- a/Bold_Vision_CRM/src/views/CustomerDetailView.vue
+++ b/Bold_Vision_CRM/src/views/CustomerDetailView.vue
@@ -37,12 +37,12 @@
 
       <div class="cd-hero__stats">
         <div class="cd-hero__stat">
-          <div class="cd-hero__stat-eyebrow">Last contact</div>
+          <div class="cd-hero__stat-eyebrow">Last follow-up</div>
           <div class="cd-hero__stat-v">{{ lastContactedShort }}</div>
           <div class="cd-hero__stat-s">{{ lastContactedSub }}</div>
         </div>
         <div class="cd-hero__stat">
-          <div class="cd-hero__stat-eyebrow">Next contact</div>
+          <div class="cd-hero__stat-eyebrow">Next follow-up</div>
           <div class="cd-hero__stat-v" :data-tone="nextContactTone">{{ nextContactShort }}</div>
           <div class="cd-hero__stat-s" :data-tone="nextContactTone">{{ nextContactSub }}</div>
         </div>
@@ -61,30 +61,64 @@
           </div>
 
           <div class="cd-form-grid">
-            <div class="field">
+            <div class="field" :class="{ 'is-error': errors.name }">
               <label for="cd-name">Full name</label>
-              <input id="cd-name" v-model="editable.name" type="text" class="input" autocomplete="name" />
+              <input id="cd-name" v-model="editable.name" type="text" class="input" autocomplete="name"
+                     :maxlength="LIMITS.name.max"
+                     @input="clearError('name')" @blur="validateField('name')" />
+              <p v-if="errors.name" class="field-error">{{ errors.name }}</p>
+              <p v-if="duplicates.name" class="cd-dup-warn">
+                <AppIcon name="user" :size="12" />
+                Same name as
+                <RouterLink :to="`/customers/${duplicates.name.id}`" class="cd-dup-link">
+                  {{ duplicates.name.name }}
+                </RouterLink>
+                — different person? Save anyway.
+              </p>
             </div>
-            <div class="field">
+            <div class="field" :class="{ 'is-error': errors.phone }">
               <label for="cd-phone">Phone</label>
               <div class="input-affix">
                 <span class="prefix"><AppIcon name="phone" :size="14" /></span>
-                <input id="cd-phone" v-model="editable.phone" type="tel" class="input has-prefix" autocomplete="tel" />
+                <input id="cd-phone" v-model="editable.phone" type="tel" class="input has-prefix" autocomplete="tel"
+                       :maxlength="LIMITS.phone.max"
+                       @input="clearError('phone')" @blur="validateField('phone'); checkDuplicates()" />
               </div>
+              <p v-if="errors.phone" class="field-error">{{ errors.phone }}</p>
+              <p v-if="duplicates.phone" class="cd-dup-error">
+                <AppIcon name="phone" :size="12" />
+                This phone already belongs to
+                <RouterLink :to="`/customers/${duplicates.phone.id}`" class="cd-dup-link">
+                  {{ duplicates.phone.name || 'an existing customer' }}
+                </RouterLink>
+              </p>
             </div>
-            <div class="field">
+            <div class="field" :class="{ 'is-error': errors.email }">
               <label for="cd-email">Email</label>
               <div class="input-affix">
                 <span class="prefix"><AppIcon name="mail" :size="14" /></span>
-                <input id="cd-email" v-model="editable.email" type="email" class="input has-prefix" autocomplete="email" />
+                <input id="cd-email" v-model="editable.email" type="email" class="input has-prefix" autocomplete="email"
+                       :maxlength="LIMITS.email.max"
+                       @input="clearError('email')" @blur="validateField('email'); checkDuplicates()" />
               </div>
+              <p v-if="errors.email" class="field-error">{{ errors.email }}</p>
+              <p v-if="duplicates.email" class="cd-dup-error">
+                <AppIcon name="mail" :size="12" />
+                This email already belongs to
+                <RouterLink :to="`/customers/${duplicates.email.id}`" class="cd-dup-link">
+                  {{ duplicates.email.name || 'an existing customer' }}
+                </RouterLink>
+              </p>
             </div>
-            <div class="field">
+            <div class="field" :class="{ 'is-error': errors.agent }">
               <label for="cd-agent">Agent</label>
               <div class="input-affix">
                 <span class="prefix"><AppIcon name="user" :size="14" /></span>
-                <input id="cd-agent" v-model="editable.agent" type="text" class="input has-prefix" placeholder="e.g. Sarah Liang" />
+                <input id="cd-agent" v-model="editable.agent" type="text" class="input has-prefix" placeholder="e.g. Sarah Liang"
+                       :maxlength="LIMITS.agent.max"
+                       @input="clearError('agent')" @blur="validateField('agent')" />
               </div>
+              <p v-if="errors.agent" class="field-error">{{ errors.agent }}</p>
             </div>
             <div class="field">
               <label for="cd-channel">Preferred channel</label>
@@ -101,7 +135,7 @@
           </div>
 
           <div class="cd-form-notes">
-            <div class="field">
+            <div class="field" :class="{ 'is-error': errors.notes }">
               <div class="field-head">
                 <label for="cd-notes">Internal notes</label>
                 <span class="field-action">Only visible to your team</span>
@@ -112,7 +146,10 @@
                 class="textarea"
                 rows="3"
                 placeholder="Family details, preferences, anything important to remember…"
+                :maxlength="LIMITS.notes.max"
+                @input="clearError('notes')" @blur="validateField('notes')"
               ></textarea>
+              <p v-if="errors.notes" class="field-error">{{ errors.notes }}</p>
             </div>
           </div>
 
@@ -121,6 +158,17 @@
             <button class="btn btn-primary" :disabled="!isDirty || saving" @click="saveChanges">
               <AppIcon name="check" :size="14" />
               {{ saving ? 'Saving…' : 'Save changes' }}
+            </button>
+          </div>
+
+          <div class="cd-danger-zone">
+            <div class="cd-danger-zone__text">
+              <strong>Delete this customer</strong>
+              <span>Permanent. Removes interactions, interests, and assessment data.</span>
+            </div>
+            <button type="button" class="btn cd-btn-danger" @click="deleteDialog = true">
+              <AppIcon name="x" :size="14" />
+              Delete customer
             </button>
           </div>
         </section>
@@ -163,6 +211,7 @@
                     class="textarea"
                     rows="2"
                     placeholder="Log a quick note from the last interaction…"
+                    :maxlength="LIMITS.notes.max"
                   ></textarea>
                   <div class="cd-quickadd__row">
                     <div class="cd-typepick" role="group">
@@ -262,7 +311,7 @@
           </div>
 
           <div class="field">
-            <label for="cd-last">Last contacted</label>
+            <label for="cd-last">Last follow-up</label>
             <div class="input-affix">
               <span class="prefix"><AppIcon name="clock" :size="14" /></span>
               <input
@@ -276,7 +325,7 @@
           </div>
 
           <div class="field" style="margin-top: 12px">
-            <label for="cd-next">Next contact</label>
+            <label for="cd-next">Next follow-up</label>
             <div class="input-affix">
               <span class="prefix"><AppIcon name="calendar" :size="14" /></span>
               <input
@@ -305,7 +354,7 @@
 
           <button class="btn btn-primary cd-mark-btn" @click="markContactedDialog = true">
             <AppIcon name="check" :size="14" />
-            Mark contacted now
+            Mark followed up now
           </button>
         </section>
 
@@ -370,30 +419,64 @@
                 <span class="cd-sec-title__sub">All fields editable</span>
               </div>
               <div class="cd-form-grid">
-                <div class="field">
+                <div class="field" :class="{ 'is-error': errors.name }">
                   <label for="cdm-name">Full name</label>
-                  <input id="cdm-name" v-model="editable.name" type="text" class="input" autocomplete="name" />
+                  <input id="cdm-name" v-model="editable.name" type="text" class="input" autocomplete="name"
+                         :maxlength="LIMITS.name.max"
+                         @input="clearError('name')" @blur="validateField('name')" />
+                  <p v-if="errors.name" class="field-error">{{ errors.name }}</p>
+                  <p v-if="duplicates.name" class="cd-dup-warn">
+                    <AppIcon name="user" :size="12" />
+                    Same name as
+                    <RouterLink :to="`/customers/${duplicates.name.id}`" class="cd-dup-link">
+                      {{ duplicates.name.name }}
+                    </RouterLink>
+                    — different person? Save anyway.
+                  </p>
                 </div>
-                <div class="field">
+                <div class="field" :class="{ 'is-error': errors.phone }">
                   <label for="cdm-phone">Phone</label>
                   <div class="input-affix">
                     <span class="prefix"><AppIcon name="phone" :size="14" /></span>
-                    <input id="cdm-phone" v-model="editable.phone" type="tel" class="input has-prefix" autocomplete="tel" />
+                    <input id="cdm-phone" v-model="editable.phone" type="tel" class="input has-prefix" autocomplete="tel"
+                           :maxlength="LIMITS.phone.max"
+                           @input="clearError('phone')" @blur="validateField('phone'); checkDuplicates()" />
                   </div>
+                  <p v-if="errors.phone" class="field-error">{{ errors.phone }}</p>
+                  <p v-if="duplicates.phone" class="cd-dup-error">
+                    <AppIcon name="phone" :size="12" />
+                    This phone already belongs to
+                    <RouterLink :to="`/customers/${duplicates.phone.id}`" class="cd-dup-link">
+                      {{ duplicates.phone.name || 'an existing customer' }}
+                    </RouterLink>
+                  </p>
                 </div>
-                <div class="field">
+                <div class="field" :class="{ 'is-error': errors.email }">
                   <label for="cdm-email">Email</label>
                   <div class="input-affix">
                     <span class="prefix"><AppIcon name="mail" :size="14" /></span>
-                    <input id="cdm-email" v-model="editable.email" type="email" class="input has-prefix" autocomplete="email" />
+                    <input id="cdm-email" v-model="editable.email" type="email" class="input has-prefix" autocomplete="email"
+                           :maxlength="LIMITS.email.max"
+                           @input="clearError('email')" @blur="validateField('email'); checkDuplicates()" />
                   </div>
+                  <p v-if="errors.email" class="field-error">{{ errors.email }}</p>
+                  <p v-if="duplicates.email" class="cd-dup-error">
+                    <AppIcon name="mail" :size="12" />
+                    This email already belongs to
+                    <RouterLink :to="`/customers/${duplicates.email.id}`" class="cd-dup-link">
+                      {{ duplicates.email.name || 'an existing customer' }}
+                    </RouterLink>
+                  </p>
                 </div>
-                <div class="field">
+                <div class="field" :class="{ 'is-error': errors.agent }">
                   <label for="cdm-agent">Agent</label>
                   <div class="input-affix">
                     <span class="prefix"><AppIcon name="user" :size="14" /></span>
-                    <input id="cdm-agent" v-model="editable.agent" type="text" class="input has-prefix" placeholder="e.g. Sarah Liang" />
+                    <input id="cdm-agent" v-model="editable.agent" type="text" class="input has-prefix" placeholder="e.g. Sarah Liang"
+                           :maxlength="LIMITS.agent.max"
+                           @input="clearError('agent')" @blur="validateField('agent')" />
                   </div>
+                  <p v-if="errors.agent" class="field-error">{{ errors.agent }}</p>
                 </div>
                 <div class="field">
                   <label for="cdm-channel">Preferred channel</label>
@@ -409,7 +492,7 @@
                 </div>
               </div>
               <div class="cd-form-notes">
-                <div class="field">
+                <div class="field" :class="{ 'is-error': errors.notes }">
                   <div class="field-head">
                     <label for="cdm-notes">Internal notes</label>
                     <span class="field-action">Only visible to your team</span>
@@ -420,7 +503,10 @@
                     class="textarea"
                     rows="3"
                     placeholder="Family details, preferences, anything important to remember…"
+                    :maxlength="LIMITS.notes.max"
+                    @input="clearError('notes')" @blur="validateField('notes')"
                   ></textarea>
+                  <p v-if="errors.notes" class="field-error">{{ errors.notes }}</p>
                 </div>
               </div>
               <div class="cd-card__actions cd-profile-actions">
@@ -428,6 +514,17 @@
                 <button class="btn btn-primary" :disabled="!isDirty || saving" @click="saveChanges">
                   <AppIcon name="check" :size="14" />
                   {{ saving ? 'Saving…' : 'Save changes' }}
+                </button>
+              </div>
+
+              <div class="cd-danger-zone">
+                <div class="cd-danger-zone__text">
+                  <strong>Delete this customer</strong>
+                  <span>Permanent. Removes interactions, interests, and assessment data.</span>
+                </div>
+                <button type="button" class="btn cd-btn-danger" @click="deleteDialog = true">
+                  <AppIcon name="x" :size="14" />
+                  Delete customer
                 </button>
               </div>
             </div>
@@ -441,7 +538,7 @@
                 </span>
               </div>
               <div class="field">
-                <label for="cdm-last">Last contacted</label>
+                <label for="cdm-last">Last follow-up</label>
                 <div class="input-affix">
                   <span class="prefix"><AppIcon name="clock" :size="14" /></span>
                   <input
@@ -454,7 +551,7 @@
                 </div>
               </div>
               <div class="field" style="margin-top: 12px">
-                <label for="cdm-next">Next contact</label>
+                <label for="cdm-next">Next follow-up</label>
                 <div class="input-affix">
                   <span class="prefix"><AppIcon name="calendar" :size="14" /></span>
                   <input
@@ -477,7 +574,7 @@
               </div>
               <button class="btn btn-primary cd-mark-btn" @click="markContactedDialog = true">
                 <AppIcon name="check" :size="14" />
-                Mark contacted now
+                Mark followed up now
               </button>
             </div>
 
@@ -529,6 +626,7 @@
                 class="textarea"
                 rows="2"
                 placeholder="Log a quick note from the last interaction…"
+                :maxlength="LIMITS.notes.max"
               ></textarea>
               <div class="cd-quickadd__row">
                 <div class="cd-typepick" role="group">
@@ -618,7 +716,7 @@
           <span class="ico"><AppIcon name="check" :size="18" /></span>
           <div class="modal-head__text">
             <h2>Log activity</h2>
-            <div class="sub">Capture how this customer was contacted and when to follow up next.</div>
+            <div class="sub">Capture how you followed up and when to follow up next.</div>
           </div>
           <button class="close" aria-label="Close" @click="markContactedDialog = false">
             <AppIcon name="x" :size="16" />
@@ -628,7 +726,7 @@
         <div class="modal-body">
           <!-- Type picker -->
           <div class="field">
-            <label>How did you contact them?</label>
+            <label>How did you follow up?</label>
             <div class="cd-typepick" role="group">
               <button
                 v-for="t in INTERACTION_TYPES"
@@ -654,6 +752,7 @@
               class="textarea"
               rows="3"
               placeholder="What was discussed? Any commitments or next steps?"
+              :maxlength="LIMITS.notes.max"
             ></textarea>
           </div>
 
@@ -675,14 +774,14 @@
           <div class="cd-mc-divider"></div>
           <div class="cd-mc-section">
             <div class="cd-mc-section__head">
-              <h4>Schedule next contact</h4>
+              <h4>Schedule next follow-up</h4>
               <label class="cd-mc-skip">
                 <input v-model="mcSkip" type="checkbox" />
                 <span>Skip</span>
               </label>
             </div>
             <div class="field">
-              <label for="mc-next">Next contact</label>
+              <label for="mc-next">Next follow-up</label>
               <div class="input-affix">
                 <span class="prefix"><AppIcon name="calendar" :size="14" /></span>
                 <input
@@ -713,12 +812,20 @@
         </div>
       </div>
     </v-dialog>
+
+    <ConfirmDeleteDialog
+      v-model="deleteDialog"
+      entity-type="customer"
+      :entity-label="editable.name"
+      :busy="deleting"
+      @confirm="confirmDelete"
+    />
   </div>
 </template>
 
 <script setup>
 import { ref, computed, watch, onMounted, onUnmounted } from 'vue'
-import { useRoute, RouterLink } from 'vue-router'
+import { useRoute, useRouter, RouterLink } from 'vue-router'
 import { useCustomerStore } from '../stores/customerStore'
 import { useAssessmentStore } from '../stores/assessmentStore'
 import {
@@ -730,6 +837,18 @@ import {
 import CustomerInterestsPanel from '../components/customer/CustomerInterestsPanel.vue'
 import BuyingProfilePanel from '../components/customer/BuyingProfilePanel.vue'
 import AppIcon from '../components/base/AppIcon.vue'
+import ConfirmDeleteDialog from '../components/base/ConfirmDeleteDialog.vue'
+import {
+  validateCustomerForm,
+  validateFeedback,
+  validateRequired,
+  validateMaxLength,
+  validatePhone,
+  validateEmail,
+  findDuplicateCustomers,
+  LIMITS,
+} from '../utils/validators'
+import { useFeedback } from '../composables/useFeedback'
 
 const CHANNELS = ['Call', 'Telegram', 'SMS', 'Email']
 const CATEGORIES = ['Hot', 'Warm', 'Cold']
@@ -748,9 +867,28 @@ function metaFor(type) {
 }
 
 const route = useRoute()
+const router = useRouter()
 const store = useCustomerStore()
 const assessmentStore = useAssessmentStore()
 const id = route.params.id
+
+const deleteDialog = ref(false)
+const deleting = ref(false)
+
+async function confirmDelete() {
+  if (deleting.value) return
+  deleting.value = true
+  try {
+    await store.deleteCustomer(id)
+    deleteDialog.value = false
+    notifySuccess('Customer deleted')
+    router.push('/customers')
+  } catch (e) {
+    notifyFromError(e, 'Failed to delete customer')
+  } finally {
+    deleting.value = false
+  }
+}
 
 const assessment = computed(() => assessmentStore.forCustomer(id))
 const assessmentCtaLabel = computed(() => {
@@ -820,14 +958,88 @@ const isDirty = computed(() => {
 })
 
 const saving = ref(false)
+const errors = ref({})
+const duplicates = ref({})
+const { notifySuccess, notifyError, notifyFromError } = useFeedback()
+
+function checkDuplicates() {
+  duplicates.value = findDuplicateCustomers(
+    { phone: editable.value.phone, email: editable.value.email, name: editable.value.name },
+    store.customers,
+    { excludeId: id },
+  )
+}
+
+const hasBlockingDuplicate = computed(
+  () => !!(duplicates.value.phone || duplicates.value.email),
+)
+
+watch(
+  () => [editable.value.phone, editable.value.email, editable.value.name, original.value?.id],
+  () => checkDuplicates(),
+  { immediate: true },
+)
+
+function clearError(field) {
+  if (errors.value[field]) {
+    const { [field]: _, ...rest } = errors.value
+    errors.value = rest
+  }
+}
+
+// Single-field validation on @blur. Composite isn't needed since the
+// at-least-one-contact rule is enforced at the DB layer (the user can't
+// blank out their only contact via this UI without seeing the toast).
+function validateField(field) {
+  let err = null
+  const val = editable.value[field]
+  switch (field) {
+    case 'name':
+      err = validateRequired(val, 'Name') ?? validateMaxLength(val, LIMITS.name.max, 'Name')
+      break
+    case 'phone':
+      err = validatePhone(val)
+      break
+    case 'email':
+      err = validateEmail(val)
+      break
+    case 'agent':
+      err = validateMaxLength(val, LIMITS.agent.max, 'Agent')
+      break
+    case 'notes':
+      err = validateMaxLength(val, LIMITS.notes.max, 'Notes')
+      break
+  }
+  if (err) errors.value = { ...errors.value, [field]: err }
+  else clearError(field)
+}
 
 async function saveChanges() {
   if (!customerFound.value || !isDirty.value) return
+  // Run the full composite validator so the "at least one contact" rule fires
+  // here too — the patch could end up clearing the only contact method.
+  const result = validateCustomerForm(editable.value)
+  if (result) {
+    errors.value = result
+    const first = result._ ?? Object.values(result)[0]
+    notifyError(first)
+    return
+  }
+  // Hard block on phone/email duplicates (name dup is just a soft warn)
+  checkDuplicates()
+  if (hasBlockingDuplicate.value) {
+    const target = duplicates.value.phone ?? duplicates.value.email
+    const field  = duplicates.value.phone ? 'phone number' : 'email'
+    notifyError(`This ${field} already belongs to ${target.name || 'an existing customer'}.`)
+    return
+  }
+  errors.value = {}
   saving.value = true
   try {
     await store.updateCustomer(id, { ...editable.value })
+    notifySuccess('Changes saved')
   } catch (e) {
-    alert(`Failed to save: ${e.message}`)
+    notifyFromError(e, 'Failed to save')
   } finally {
     saving.value = false
   }
@@ -836,6 +1048,7 @@ async function saveChanges() {
 function resetChanges() {
   if (!original.value) return
   editable.value = { ...editable.value, ...original.value }
+  errors.value = {}
 }
 
 // ── Hero stats ──────────────────────────────────────────────────────────────
@@ -862,7 +1075,7 @@ const lastContactedShort = computed(() =>
 )
 const lastContactedSub = computed(() => {
   const v = editable.value.lastContactedAt
-  if (!v) return 'No contact logged yet'
+  if (!v) return 'No follow-up logged yet'
   return `${formatTime(v)} · ${editable.value.channel || 'Call'}`
 })
 
@@ -903,7 +1116,7 @@ const statusBadge = computed(() => {
     const d = daysUntilContact(editable.value)
     return { label: `Due in ${d}d`, cls: 'warm' }
   }
-  if (s === 'never-contacted') return { label: 'Never contacted', cls: 'muted' }
+  if (s === 'never-contacted') return { label: 'No follow-ups yet', cls: 'muted' }
   if (s === 'unscheduled') return { label: 'No schedule', cls: 'muted' }
   return null
 })
@@ -1004,6 +1217,14 @@ const mcCanConfirm = computed(() => !!mcNote.value.trim() && !mcSaving.value)
 
 async function confirmMarkContacted() {
   if (!mcCanConfirm.value) return
+  // Validate before sending
+  const note = mcNote.value.trim()
+  const durationMinutes = mcType.value === 'call' ? mcDuration.value : null
+  const errs = validateFeedback({ note, type: mcType.value, durationMinutes })
+  if (errs) {
+    notifyError(errs.note ?? errs.durationMinutes ?? errs.type ?? 'Invalid input')
+    return
+  }
   mcSaving.value = true
   const now = new Date().toISOString()
   const nextIso = mcSkip.value || !mcNextDate.value ? null : new Date(mcNextDate.value).toISOString()
@@ -1012,14 +1233,15 @@ async function confirmMarkContacted() {
       lastContactedIso: now,
       nextContactIso: nextIso,
       type: mcType.value,
-      note: mcNote.value.trim(),
-      durationMinutes: mcType.value === 'call' ? mcDuration.value : null,
+      note,
+      durationMinutes,
     })
     editable.value.lastContactedAt = now
     editable.value.nextContactAt = nextIso
     markContactedDialog.value = false
+    notifySuccess('Logged')
   } catch (e) {
-    alert(`Failed to log: ${e.message}`)
+    notifyFromError(e, 'Failed to log')
   } finally {
     mcSaving.value = false
   }
@@ -1100,13 +1322,19 @@ function onMatchProperty() {
 async function addFeedback() {
   const note = newFeedback.value.trim()
   if (!note || !customerFound.value) return
+  // Length safety net before send
+  const errs = validateFeedback({ note, type: quickType.value, durationMinutes: null })
+  if (errs) {
+    notifyError(errs.note ?? errs.type ?? 'Invalid input')
+    return
+  }
   addingFeedback.value = true
   try {
     await store.addFeedback(id, { note, type: quickType.value })
     newFeedback.value = ''
     quickType.value = 'note'
   } catch (e) {
-    alert(`Failed to log activity: ${e.message}`)
+    notifyFromError(e, 'Failed to log activity')
   } finally {
     addingFeedback.value = false
   }
@@ -1345,6 +1573,99 @@ async function copyEnrollment() {
   margin-top: 18px;
   padding-top: 18px;
   border-top: 1px solid var(--border);
+}
+
+/* Soft duplicate warning (name) — yellow, allows save */
+.cd-dup-warn {
+  margin: 4px 0 0;
+  padding: 6px 10px;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  color: oklch(45% 0.13 75);
+  background: oklch(96% 0.04 75);
+  border: 1px solid oklch(80% 0.10 75);
+  border-radius: var(--r-md);
+}
+:root[data-theme="dark"] .cd-dup-warn {
+  background: oklch(28% 0.06 75);
+  border-color: oklch(40% 0.10 75);
+  color: oklch(85% 0.10 75);
+}
+
+/* Hard duplicate error (phone / email) — red, blocks save */
+.cd-dup-error {
+  margin: 4px 0 0;
+  padding: 6px 10px;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  color: var(--danger, oklch(45% 0.18 27));
+  background: oklch(96% 0.03 27);
+  border: 1px solid oklch(80% 0.10 27);
+  border-radius: var(--r-md);
+}
+:root[data-theme="dark"] .cd-dup-error {
+  background: oklch(28% 0.06 27);
+  border-color: oklch(40% 0.10 27);
+  color: oklch(85% 0.10 27);
+}
+
+.cd-dup-link {
+  color: inherit;
+  text-decoration: underline;
+  font-weight: 600;
+}
+.cd-dup-link:hover { opacity: 0.85; }
+
+/* Danger zone — delete-customer affordance, kept far from primary actions */
+.cd-danger-zone {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  margin-top: 20px;
+  padding: 14px 16px;
+  border: 1px dashed oklch(80% 0.10 27);
+  border-radius: var(--r-md);
+  background: oklch(98% 0.015 27);
+}
+:root[data-theme="dark"] .cd-danger-zone {
+  background: oklch(24% 0.04 27);
+  border-color: oklch(40% 0.10 27);
+}
+.cd-danger-zone__text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+.cd-danger-zone__text strong {
+  font-size: 13.5px;
+  color: var(--text);
+}
+.cd-danger-zone__text span {
+  font-size: 12px;
+  color: var(--text-muted);
+}
+.cd-btn-danger {
+  background: var(--danger, oklch(56% 0.20 27));
+  color: oklch(100% 0 0);
+  border: none;
+  flex-shrink: 0;
+}
+.cd-btn-danger:hover:not(:disabled) {
+  background: oklch(50% 0.20 27);
+}
+@media (max-width: 600px) {
+  .cd-danger-zone {
+    flex-direction: column;
+    align-items: stretch;
+    text-align: center;
+  }
+  .cd-btn-danger { justify-content: center; }
 }
 
 /* ── Quick add ──────────────────────────────────────── */

--- a/Bold_Vision_CRM/src/views/CustomersView.vue
+++ b/Bold_Vision_CRM/src/views/CustomersView.vue
@@ -35,7 +35,7 @@
             <th class="col-agent">Agent</th>
             <th class="col-channel">Phone · Channel</th>
             <th class="col-status">Status</th>
-            <th class="col-followup">Last contact</th>
+            <th class="col-followup">Last follow-up</th>
             <th class="col-actions"></th>
           </tr>
         </thead>
@@ -189,13 +189,16 @@ import CustomerFilterDialog from '../components/customer/CustomerFilterDialog.vu
 import { useFilterChips } from '../composables/useFilterChips'
 import { daysUntilContact, isOverdue } from '../utils/followUp'
 import { useRouter } from 'vue-router'
+import { useFeedback } from '../composables/useFeedback'
+
+const { notifySuccess, notifyFromError } = useFeedback()
 
 const router = useRouter()
 const store = useCustomerStore()
 const customers = computed(() => store.customers)
 
 const SORT_OPTIONS = [
-  { value: 'last-contact', label: 'Last contact' },
+  { value: 'last-contact', label: 'Last follow-up' },
   { value: 'overdue',      label: 'Overdue first' },
   { value: 'status',       label: 'Status' },
   { value: 'name',         label: 'Name (A–Z)' },
@@ -300,8 +303,9 @@ async function handleAddCustomer(payload) {
   try {
     await store.addCustomer(payload)
     showAddCustomer.value = false
+    notifySuccess('Customer added')
   } catch (e) {
-    alert(`Failed to add customer: ${e.message}`)
+    notifyFromError(e, 'Failed to add customer')
   }
 }
 

--- a/Bold_Vision_CRM/src/views/FollowUpsView.vue
+++ b/Bold_Vision_CRM/src/views/FollowUpsView.vue
@@ -189,19 +189,22 @@
           <div class="split-grid cols-2">
             <div class="field">
               <label for="fu-r-date">Date</label>
-              <input id="fu-r-date" v-model="rescheduleDialog.date" type="date" class="input" />
+              <input id="fu-r-date" v-model="rescheduleDialog.date" type="date" class="input" required />
             </div>
             <div class="field">
               <label for="fu-r-time">Time</label>
-              <input id="fu-r-time" v-model="rescheduleDialog.time" type="time" class="input" />
+              <input id="fu-r-time" v-model="rescheduleDialog.time" type="time" class="input" required />
             </div>
           </div>
+          <p v-if="rescheduleErrorMsg" class="field-error fu-dialog-err">{{ rescheduleErrorMsg }}</p>
         </div>
         <div class="modal-foot modal-foot--split">
           <button type="button" class="btn btn-ghost" @click="clearScheduleFromDialog">Clear schedule</button>
           <div class="actions">
             <button type="button" class="btn btn-ghost" @click="rescheduleDialog.open = false">Cancel</button>
-            <button type="button" class="btn btn-primary" @click="confirmReschedule">
+            <button type="button" class="btn btn-primary"
+                    :disabled="!!rescheduleErrorMsg || !rescheduleDialog.date"
+                    @click="confirmReschedule">
               <AppIcon name="check" :size="14" />
               Confirm
             </button>
@@ -216,7 +219,7 @@
         <header class="modal-head">
           <span class="ico"><AppIcon name="check" :size="18" /></span>
           <div class="modal-head__text">
-            <h2>Mark contacted</h2>
+            <h2>Mark followed up</h2>
             <div class="sub">{{ markContactedDialog.customer?.name }}</div>
           </div>
           <button class="close" aria-label="Close" @click="markContactedDialog.open = false">
@@ -225,33 +228,40 @@
         </header>
         <div class="modal-body">
           <div class="modal-section">
-            <p class="fu-dialog-hint">Last contacted will be set to <strong>now</strong>.</p>
+            <p class="fu-dialog-hint">Last follow-up will be set to <strong>now</strong>.</p>
           </div>
           <div class="modal-section">
-            <h4>Next contact</h4>
+            <h4>Next follow-up</h4>
             <div class="split-grid cols-2">
               <div class="field">
                 <label for="fu-mc-date">Date</label>
-                <input id="fu-mc-date" v-model="markContactedDialog.date" type="date" class="input" :disabled="markContactedDialog.skip" />
+                <input id="fu-mc-date" v-model="markContactedDialog.date" type="date" class="input"
+                       :disabled="markContactedDialog.skip"
+                       :required="!markContactedDialog.skip" />
               </div>
               <div class="field">
                 <label for="fu-mc-time">Time</label>
-                <input id="fu-mc-time" v-model="markContactedDialog.time" type="time" class="input" :disabled="markContactedDialog.skip" />
+                <input id="fu-mc-time" v-model="markContactedDialog.time" type="time" class="input"
+                       :disabled="markContactedDialog.skip"
+                       :required="!markContactedDialog.skip" />
               </div>
             </div>
+            <p v-if="markContactedErrorMsg" class="field-error fu-dialog-err">{{ markContactedErrorMsg }}</p>
             <button type="button" class="btn btn-ghost sm" :disabled="markContactedDialog.skip" @click="applyDefaultCadence">
               <AppIcon name="sparkle" :size="13" />
               {{ cadenceButtonLabel }}
             </button>
             <label class="fu-dialog-skip">
               <input type="checkbox" v-model="markContactedDialog.skip" />
-              Skip — don't schedule next contact
+              Skip — don't schedule next follow-up
             </label>
           </div>
         </div>
         <div class="modal-foot">
           <button type="button" class="btn btn-ghost" @click="markContactedDialog.open = false">Cancel</button>
-          <button type="button" class="btn btn-primary" @click="confirmMarkContacted">
+          <button type="button" class="btn btn-primary"
+                  :disabled="!!markContactedErrorMsg || (!markContactedDialog.skip && !markContactedDialog.date)"
+                  @click="confirmMarkContacted">
             <AppIcon name="check" :size="14" />
             Confirm
           </button>
@@ -269,6 +279,21 @@ import { cadenceMonths, cadenceLabel } from '../utils/followUp'
 import KanbanCard from '../components/followups/KanbanCard.vue'
 import FollowUpsFilterDialog from '../components/followups/FollowUpsFilterDialog.vue'
 import AppIcon from '../components/base/AppIcon.vue'
+import { validateDateMaxFuture } from '../utils/validators'
+import { useFeedback } from '../composables/useFeedback'
+
+const { notifySuccess, notifyError, notifyFromError } = useFeedback()
+
+// Reschedule + mark-contacted both schedule a future next-contact. The native
+// `<input type="time">` always supplies HH:MM, so we can do a strict moment
+// comparison — past = strictly before now, not before midnight today.
+function validateScheduleDate(date, time) {
+  if (!date) return 'Date is required'
+  const t = Date.parse(`${date}T${time || '09:00'}`)
+  if (Number.isNaN(t)) return 'Date is not valid'
+  if (t < Date.now()) return "Date and time can't be in the past"
+  return validateDateMaxFuture(`${date}T${time || '09:00'}`, 2, 'Date')
+}
 
 const store = useCustomerStore()
 const customers = computed(() => store.customers)
@@ -416,6 +441,15 @@ function onDrop(target) {
 // ── Reschedule dialog ───────────────────────────────────────────────────────
 const rescheduleDialog = ref({ open: false, customer: null, date: '', time: '' })
 
+// Inline error display: only complain about format/range once the agent has
+// actually picked something. An empty-date dialog shows no error yet — the
+// Confirm button is disabled instead.
+const rescheduleErrorMsg = computed(() => {
+  const { date, time } = rescheduleDialog.value
+  if (!date) return null
+  return validateScheduleDate(date, time)
+})
+
 function openRescheduleFor(customer, date) {
   const existing = customer.nextContactAt ? new Date(customer.nextContactAt) : null
   const targetDate = date ?? new Date()
@@ -429,20 +463,40 @@ function openRescheduleFor(customer, date) {
 
 async function confirmReschedule() {
   const { customer, date, time } = rescheduleDialog.value
-  if (!date) { rescheduleDialog.value.open = false; return }
+  const err = validateScheduleDate(date, time)
+  if (err) { notifyError(err); return }
   const iso = new Date(`${date}T${time || '09:00'}`).toISOString()
-  await store.setNextContactAt(customer.id, iso)
-  rescheduleDialog.value.open = false
+  try {
+    await store.setNextContactAt(customer.id, iso)
+    rescheduleDialog.value.open = false
+    notifySuccess(`Rescheduled ${customer.name}`)
+  } catch (e) {
+    notifyFromError(e, 'Failed to reschedule')
+  }
 }
 
 async function clearScheduleFromDialog() {
   const { customer } = rescheduleDialog.value
-  if (customer) await store.setNextContactAt(customer.id, null)
-  rescheduleDialog.value.open = false
+  if (!customer) return
+  try {
+    await store.setNextContactAt(customer.id, null)
+    rescheduleDialog.value.open = false
+    notifySuccess(`Cleared next follow-up for ${customer.name}`)
+  } catch (e) {
+    notifyFromError(e, 'Failed to clear schedule')
+  }
 }
 
 // ── Mark contacted dialog ───────────────────────────────────────────────────
 const markContactedDialog = ref({ open: false, customer: null, date: '', time: '', skip: false })
+
+// Same pattern as reschedule — but if "skip" is on, no schedule needed so no
+// error to surface.
+const markContactedErrorMsg = computed(() => {
+  const { date, time, skip } = markContactedDialog.value
+  if (skip || !date) return null
+  return validateScheduleDate(date, time)
+})
 
 function openMarkContacted(customer) {
   markContactedDialog.value = { open: true, customer, date: '', time: '', skip: false }
@@ -466,10 +520,20 @@ function applyDefaultCadence() {
 
 async function confirmMarkContacted() {
   const { customer, date, time, skip } = markContactedDialog.value
+  // Validate date only when the agent intends to schedule a next contact
+  if (!skip && date) {
+    const err = validateScheduleDate(date, time)
+    if (err) { notifyError(err); return }
+  }
   const now = new Date().toISOString()
   const nextIso = skip || !date ? null : new Date(`${date}T${time || '09:00'}`).toISOString()
-  await store.logContact(customer.id, { lastContactedIso: now, nextContactIso: nextIso })
-  markContactedDialog.value.open = false
+  try {
+    await store.logContact(customer.id, { lastContactedIso: now, nextContactIso: nextIso })
+    markContactedDialog.value.open = false
+    notifySuccess(`Marked ${customer.name} as followed up`)
+  } catch (e) {
+    notifyFromError(e, 'Failed to log')
+  }
 }
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
@@ -529,6 +593,7 @@ function shortDateLabel(date) {
   margin-top: 8px;
 }
 .fu-dialog-skip input[type="checkbox"] { cursor: pointer; }
+.fu-dialog-err { margin-top: 10px; }
 
 /* Filter count badge inside the Filters button */
 .fu-controls .btn .tab-ct {

--- a/Bold_Vision_CRM/src/views/LoginView.vue
+++ b/Bold_Vision_CRM/src/views/LoginView.vue
@@ -17,7 +17,7 @@
             type="email"
             variant="outlined"
             prepend-inner-icon="mdi-email-outline"
-            :rules="[(v) => !!v || 'Email is required']"
+            :rules="emailRules"
             class="mb-3"
             autocomplete="email"
           />
@@ -50,6 +50,7 @@ import { ref } from 'vue'
 import { useRouter, useRoute } from 'vue-router'
 import { useAuthStore } from '../stores/authStore'
 import { signIn } from '../services/authService'
+import { validateEmail } from '../utils/validators'
 
 const router = useRouter()
 const route = useRoute()
@@ -61,6 +62,12 @@ const password = ref('')
 const showPassword = ref(false)
 const loading = ref(false)
 const error = ref('')
+
+// "required" + format. validateEmail returns null on success or error string.
+const emailRules = [
+  (v) => !!v || 'Email is required',
+  (v) => validateEmail(v) === null || validateEmail(v),
+]
 
 async function submit() {
   const { valid } = await form.value.validate()

--- a/Bold_Vision_CRM/src/views/LoginView.vue
+++ b/Bold_Vision_CRM/src/views/LoginView.vue
@@ -82,12 +82,25 @@ async function retryInit() {
     // If retry succeeded AND there's now a session, jump them to where they
     // were headed.
     if (authStore.session) {
-      const redirect = route.query.redirect || '/'
-      router.push(redirect)
+      router.push(safeRedirect(route.query.redirect))
     }
   } finally {
     retrying.value = false
   }
+}
+
+// H14: validate the `redirect` query param before pushing the router to it.
+// Without this, a crafted link like /login?redirect=https://evil.com would
+// bounce signed-in users to an attacker site (phishing assist). Only accept
+// single-leading-slash absolute paths — reject protocol-relative ('//...'),
+// backslash variants (some browsers treat '/\evil.com' as cross-origin), and
+// non-strings. Legitimate redirects from the router guard are always
+// `to.fullPath` which starts with a single '/'.
+function safeRedirect(input) {
+  if (typeof input !== 'string') return '/'
+  if (!input.startsWith('/')) return '/'
+  if (input.startsWith('//') || input.startsWith('/\\')) return '/'
+  return input
 }
 
 // "required" + format. validateEmail returns null on success or error string.
@@ -106,8 +119,7 @@ async function submit() {
     const { session } = await signIn({ email: email.value, password: password.value })
     authStore.session = session
     authStore.user = session?.user ?? null
-    const redirect = route.query.redirect || '/'
-    router.push(redirect)
+    router.push(safeRedirect(route.query.redirect))
   } catch (e) {
     error.value = e.message || 'Sign in failed. Check your credentials.'
   } finally {

--- a/Bold_Vision_CRM/src/views/LoginView.vue
+++ b/Bold_Vision_CRM/src/views/LoginView.vue
@@ -33,6 +33,12 @@
             autocomplete="current-password"
             @click:append-inner="showPassword = !showPassword"
           />
+          <v-alert v-if="initError" type="warning" class="mb-3" density="compact" rounded="lg">
+            <div class="mb-2">{{ initError }}</div>
+            <v-btn size="small" variant="tonal" :loading="retrying" @click="retryInit">
+              Retry connection
+            </v-btn>
+          </v-alert>
           <v-alert v-if="error" type="error" class="mb-4" density="compact" rounded="lg">
             {{ error }}
           </v-alert>
@@ -46,8 +52,9 @@
 </template>
 
 <script setup>
-import { ref } from 'vue'
+import { ref, computed } from 'vue'
 import { useRouter, useRoute } from 'vue-router'
+import { storeToRefs } from 'pinia'
 import { useAuthStore } from '../stores/authStore'
 import { signIn } from '../services/authService'
 import { validateEmail } from '../utils/validators'
@@ -55,13 +62,33 @@ import { validateEmail } from '../utils/validators'
 const router = useRouter()
 const route = useRoute()
 const authStore = useAuthStore()
+const { initError } = storeToRefs(authStore)
 
 const form = ref()
 const email = ref('')
 const password = ref('')
 const showPassword = ref(false)
 const loading = ref(false)
+const retrying = ref(false)
 const error = ref('')
+
+// C8: if authStore.init() failed at boot (Supabase unreachable), the user
+// lands here with `initError` set on the store. The Retry button re-runs
+// init() so they don't have to refresh the page.
+async function retryInit() {
+  retrying.value = true
+  try {
+    await authStore.init()
+    // If retry succeeded AND there's now a session, jump them to where they
+    // were headed.
+    if (authStore.session) {
+      const redirect = route.query.redirect || '/'
+      router.push(redirect)
+    }
+  } finally {
+    retrying.value = false
+  }
+}
 
 // "required" + format. validateEmail returns null on success or error string.
 const emailRules = [

--- a/Bold_Vision_CRM/src/views/PropertiesView.vue
+++ b/Bold_Vision_CRM/src/views/PropertiesView.vue
@@ -118,6 +118,9 @@ import { useFilterChips } from '../composables/useFilterChips'
 import { createEmptyPropertyDraft } from '../constants/propertyDefaults'
 import { statusToClass } from '../utils/property'
 import { formatSqm } from '../utils/formatters'
+import { useFeedback } from '../composables/useFeedback'
+
+const { notifySuccess, notifyFromError } = useFeedback()
 
 const propertyStore = usePropertyStore()
 const properties = computed(() => propertyStore.properties)
@@ -284,16 +287,13 @@ function handleFilterClear() {
 
 async function handleAddProperty(payload) {
   const propertyData = payload || newProperty.value
-  if (!propertyData.address || !propertyData.type || !propertyData.status) {
-    alert('Please fill in at least address, type, and status.')
-    return
-  }
   try {
     await propertyStore.addProperty({ ...propertyData })
     newProperty.value = createEmptyPropertyDraft()
     showAddProperty.value = false
+    notifySuccess('Property added')
   } catch (e) {
-    alert(`Failed to save property: ${e.message}`)
+    notifyFromError(e, 'Failed to save property')
   }
 }
 

--- a/Bold_Vision_CRM/src/views/PropertyDetailsView.vue
+++ b/Bold_Vision_CRM/src/views/PropertyDetailsView.vue
@@ -193,12 +193,23 @@
 
                 <!-- Details tab: the overview form -->
                 <template v-if="activeTab === 'details'">
-                  <PropertyForm v-model="editable" />
+                  <PropertyForm ref="propertyFormRef" v-model="editable" />
                   <div class="pd-form-footer">
                     <button class="btn btn-ghost" :disabled="!hasUnsavedChanges" @click="resetChanges">Reset</button>
                     <button class="btn btn-primary" :disabled="!hasUnsavedChanges" @click="saveChanges">
                       <AppIcon name="check" :size="14" /> Save changes
                       <span v-if="hasUnsavedChanges" class="save-dot" />
+                    </button>
+                  </div>
+
+                  <div class="pd-danger-zone">
+                    <div class="pd-danger-zone__text">
+                      <strong>Delete this property</strong>
+                      <span>Permanent. Removes photos, floor plans, interests, and broadcast history.</span>
+                    </div>
+                    <button type="button" class="btn pd-btn-danger" @click="deleteDialog = true">
+                      <AppIcon name="x" :size="14" />
+                      Delete property
                     </button>
                   </div>
                 </template>
@@ -237,9 +248,14 @@
       />
     </v-dialog>
 
-    <v-snackbar v-model="snackbar" timeout="2000" color="success">
-      Changes saved successfully.
-    </v-snackbar>
+    <ConfirmDeleteDialog
+      v-model="deleteDialog"
+      entity-type="property"
+      :entity-label="original?.address ?? ''"
+      :busy="deleting"
+      @confirm="confirmDelete"
+    />
+
   </div>
 
   <!-- ── Not found ──────────────────────────────────────────── -->
@@ -262,8 +278,13 @@ import PropertyInterestsPanel from '../components/properties/PropertyInterestsPa
 import BroadcastPanel from '../components/properties/BroadcastPanel.vue'
 import PhotoLightbox from '../components/properties/PhotoLightbox.vue'
 import AppIcon from '../components/base/AppIcon.vue'
+import ConfirmDeleteDialog from '../components/base/ConfirmDeleteDialog.vue'
 import { statusToClass } from '../utils/property'
 import { formatSqm } from '../utils/formatters'
+import { useFeedback } from '../composables/useFeedback'
+import { validatePhotoFile, LIMITS } from '../utils/validators'
+
+const { notifySuccess, notifyError, notifyFromError } = useFeedback()
 
 const route  = useRoute()
 const router = useRouter()
@@ -276,7 +297,9 @@ const original      = computed(() => propertyStore.properties.find((p) => p.id =
 const propertyFound = computed(() => !!original.value)
 
 const editable       = ref(createEmptyPropertyDraft())
-const snackbar       = ref(false)
+const propertyFormRef = ref(null)
+const deleteDialog   = ref(false)
+const deleting       = ref(false)
 const photoUploading = ref(false)
 const photoError     = ref(null)
 const broadcastOpen  = ref(false)
@@ -349,14 +372,39 @@ const tabMeta = computed(() => {
   }
 })
 
-function saveChanges() {
+async function saveChanges() {
   if (!propertyFound.value) return
-  propertyStore.updateProperty(id, { ...editable.value })
-  snackbar.value = true
+  const errs = propertyFormRef.value?.validate()
+  if (errs) {
+    const first = errs._ ?? Object.values(errs)[0]
+    notifyError(first)
+    return
+  }
+  try {
+    await propertyStore.updateProperty(id, { ...editable.value })
+    notifySuccess('Changes saved')
+  } catch (e) {
+    notifyFromError(e, 'Failed to save')
+  }
 }
 
 function resetChanges() {
   if (original.value) editable.value = { ...createEmptyPropertyDraft(), ...original.value }
+}
+
+async function confirmDelete() {
+  if (deleting.value) return
+  deleting.value = true
+  try {
+    await propertyStore.deleteProperty(id)
+    deleteDialog.value = false
+    notifySuccess('Property deleted')
+    router.push({ name: 'properties' })
+  } catch (e) {
+    notifyFromError(e, 'Failed to delete property')
+  } finally {
+    deleting.value = false
+  }
 }
 
 function goBack() { router.push({ name: 'properties' }) }
@@ -428,10 +476,31 @@ onMounted(() => {
 // ── photo handlers ───────────────────────────────────────────
 async function handleAdd(files, kind) {
   photoError.value = null
+
+  // Pre-flight: filter out files that fail size/type checks BEFORE upload.
+  // Bucket policy will also reject, but catching here gives instant feedback.
+  const valid = []
+  const skipped = []
+  for (const file of files) {
+    const err = validatePhotoFile(file)
+    if (err) skipped.push(`${file.name}: ${err}`)
+    else valid.push(file)
+  }
+  if (skipped.length) {
+    notifyError(`Skipped ${skipped.length} file${skipped.length === 1 ? '' : 's'} — ${skipped[0]}`)
+  }
+  if (valid.length > LIMITS.photoBatch.max) {
+    notifyError(`Too many at once — uploading first ${LIMITS.photoBatch.max} of ${valid.length}`)
+    valid.length = LIMITS.photoBatch.max
+  }
+  if (!valid.length) return
+
   photoUploading.value = true
   try {
-    for (const file of files) await propertyStore.uploadPhoto(id, file, kind)
+    for (const file of valid) await propertyStore.uploadPhoto(id, file, kind)
+    notifySuccess(`Uploaded ${valid.length} ${kind === 'floorplan' ? 'floor plan' : 'photo'}${valid.length === 1 ? '' : 's'}`)
   } catch (e) {
+    notifyFromError(e, 'Upload failed')
     photoError.value = `Upload failed: ${e.message}`
   } finally {
     photoUploading.value = false
@@ -722,6 +791,35 @@ async function handleSelect(storagePath) {
 }
 .pd-form-footer .btn-primary {
   display: inline-flex; align-items: center; gap: 6px;
+}
+
+/* ── Danger zone (delete property) ──────────────────────────── */
+.pd-danger-zone {
+  display: flex; align-items: center; justify-content: space-between;
+  gap: 16px; margin-top: 20px; padding: 14px 16px;
+  border: 1px dashed oklch(80% 0.10 27);
+  border-radius: var(--r-md);
+  background: oklch(98% 0.015 27);
+}
+:root[data-theme="dark"] .pd-danger-zone {
+  background: oklch(24% 0.04 27);
+  border-color: oklch(40% 0.10 27);
+}
+.pd-danger-zone__text { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
+.pd-danger-zone__text strong { font-size: 13.5px; color: var(--text); }
+.pd-danger-zone__text span   { font-size: 12px; color: var(--text-muted); }
+.pd-btn-danger {
+  background: var(--danger, oklch(56% 0.20 27));
+  color: oklch(100% 0 0);
+  border: none;
+  flex-shrink: 0;
+}
+.pd-btn-danger:hover:not(:disabled) {
+  background: oklch(50% 0.20 27);
+}
+@media (max-width: 600px) {
+  .pd-danger-zone { flex-direction: column; align-items: stretch; text-align: center; }
+  .pd-btn-danger { justify-content: center; }
 }
 
 /* ── Agent card (kept for reuse) ────────────────────────────── */

--- a/Bold_Vision_CRM/vercel.json
+++ b/Bold_Vision_CRM/vercel.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "buildCommand": "npm run build",
+  "outputDirectory": "dist",
+  "framework": "vite",
+
+  "rewrites": [
+    { "source": "/(.*)", "destination": "/index.html" }
+  ],
+
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        { "key": "Strict-Transport-Security", "value": "max-age=31536000; includeSubDomains; preload" },
+        { "key": "X-Content-Type-Options",    "value": "nosniff" },
+        { "key": "X-Frame-Options",           "value": "DENY" },
+        { "key": "Referrer-Policy",           "value": "strict-origin-when-cross-origin" },
+        { "key": "Permissions-Policy",        "value": "camera=(), microphone=(), geolocation=(), payment=()" },
+        { "key": "Content-Security-Policy",   "value": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; font-src 'self' data:; img-src 'self' data: blob: https:; connect-src 'self' https://cvwlrsjxgegwwptkdlma.supabase.co wss://cvwlrsjxgegwwptkdlma.supabase.co; frame-ancestors 'none'; base-uri 'self'; form-action 'self'" }
+      ]
+    },
+    {
+      "source": "/index.html",
+      "headers": [
+        { "key": "Cache-Control", "value": "public, max-age=0, must-revalidate" }
+      ]
+    },
+    {
+      "source": "/assets/(.*)",
+      "headers": [
+        { "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }
+      ]
+    }
+  ]
+}

--- a/Bold_Vision_CRM/vite.config.js
+++ b/Bold_Vision_CRM/vite.config.js
@@ -3,13 +3,24 @@ import { defineConfig } from 'vite'
 import vue from '@vitejs/plugin-vue'
 import vueDevTools from 'vite-plugin-vue-devtools'
 
+// Phase 8 Stage 1:
+// - C6: `base: '/'` so production-built assets resolve at the site root
+//   (previously '/CRM-Project/' for GitHub Pages preview; would 404 every
+//   asset on Vercel / any non-subpath host).
+// - C9: vueDevTools loads only in dev. Shipping the Vue + Pinia state
+//   inspector to production bundle is a bundle-size + info-leak cost
+//   (internal store state visible via the devtools panel).
+//
 // https://vite.dev/config/
 export default defineConfig({
-  plugins: [vue(), vueDevTools()],
+  plugins: [
+    vue(),
+    ...(process.env.NODE_ENV === 'development' ? [vueDevTools()] : []),
+  ],
   resolve: {
     alias: {
       '@': fileURLToPath(new URL('./src', import.meta.url)),
     },
   },
-  base: '/CRM-Project/',
+  base: '/',
 })

--- a/docs/PHASE8-HANDOFF.md
+++ b/docs/PHASE8-HANDOFF.md
@@ -1,0 +1,136 @@
+# Phase 8 Handoff — Input Validation Slice (Slice 1 + 1b)
+
+**Branch:** `Feature/Phase8-InputValidation` (off `main` at `8d04305`)
+**State:** Working tree dirty with Slice 1 + 1b changes. **Not committed, not merged.**
+**Date:** 2026-05-18
+**Full audit:** [`C:\Users\limsa\.claude\plans\crispy-shimmying-valiant.md`](../../Users/limsa/.claude/plans/crispy-shimmying-valiant.md)
+
+---
+
+## What shipped
+
+### Slice 1 — Input validation (defense in depth)
+
+Three layers, every user input is gated by at least one:
+
+| Layer | Where | What it catches |
+|---|---|---|
+| **Frontend rules** | New `src/utils/validators.js` — pure functions returning `null` or error string | 99% of typos / format errors / range violations before submit |
+| **Service-layer guards** | `normalize{Entity}Payload()` helpers throw `ValidationError` | Programmatic bypass, optimistic-update drift, mismatched types |
+| **DB constraints** | Migration `supabase/migrations/0012_customer_unique_contacts.sql` (functional UNIQUE indexes on phone + email per agent) | Direct API calls, future regressions |
+
+Covers: AddCustomerDialog (+ duplicate phone/email **hard-block**, duplicate name **soft-warn**), CustomerDetailView basic-info edit, quick-log activity dialog, reschedule dialog, PropertiesForm (incl. `validate()` exposed via `defineExpose` for parent gate), all 7 assessment sections (currency parser hardened, keystroke filters for currency/integer/decimal/date-text), BroadcastPanel (4096-char body cap + counter), FollowUpsView reschedule + mark-followed-up dialogs (strict time, 2-year future cap), PropertyDetailsView photo upload (MIME + size + batch cap).
+
+New shared infrastructure:
+- `src/composables/useFeedback.js` + `src/components/base/AppSnackbar.vue` — module-scoped reactive toast, mounted once in `App.vue`. Replaces every per-component v-snackbar.
+- `src/components/base/ConfirmDeleteDialog.vue` — typed-`CONFIRM` gate; wired into customer + property delete (new feature).
+- `src/utils/inputFilters.js` — `@keydown` filters: currency, integer, decimal, date-text.
+
+Bug fixes along the way:
+- Follow-up overdue logic — same-day past-time cards now correctly bucketize as overdue (was rounding to "today"). See `src/utils/followUp.js`.
+- Mirrored-field debounce in CustomerAssessmentView bumped 1000→2500ms so agent-clear-then-retype doesn't snap back mid-edit.
+- Validation errors during debounced autosave now surface via `notifyFromError` + drop the pending value (was silently swallowing).
+
+### Slice 1b — Assessment N/A flags + three-state completion
+
+Replaces the misleading "touched = complete" nav rendering. New flow:
+
+- **Untouched** → grey numbered circle (default)
+- **In-progress** → amber dot (touched but at least one optional field is blank without N/A)
+- **Complete** → green check (every required field is filled, every optional field is either filled or explicitly N/A'd)
+
+`computeSectionStatus(sectionKey, assessment)` in `validators.js` is the single source of truth. Per-section completion rules encoded directly in the function.
+
+**N/A flag storage** (additive, no migration):
+- Client-split sections (Personal/Employment/Income): `payload.client1.na = { fieldKey: true }`
+- Flat sections (Assets/Discovery/Notes): `payload.na = { fieldKey: true }`
+- Liabilities only: `payload.naSection: true` (whole-section toggle — "No liabilities to record")
+
+**N/A UI:** new `src/components/assessment/NAButton.vue` pill placed next to every optional field. On activate: clears the value, disables + greys the input, swaps placeholder to "N/A", and counts toward "complete". Liabilities' section toggle hides the row table entirely.
+
+**Print contract** (documented at top of `validateAssessmentSection`, no UI yet):
+- `na[field] === true` → render "N/A"
+- value present → render value
+- blank + no NA flag → render "—" (signals agent left blank without explicit decision)
+
+### Bonus — end-of-session deep-scan fixes
+
+A second-pass Explore agent audited every input across the app for missed validation. Real gaps found + fixed:
+
+- **LoginView** email format rule (`validateEmail` via Vuetify `:rules`). Password length **deliberately not added** — Supabase enforces server-side; client-side stricter would lock out existing users.
+- **BaseSearchBar** `maxlength="200"` prop (defaults 200) — covers Customers/Properties/Follow-ups search.
+- **Customer + Property interest pickers** `maxlength="200"` on internal search input.
+- **FollowUpsView reschedule + mark-followed-up dialogs** — `required` attr on date/time inputs, inline `<p class="field-error">` with reactive `rescheduleErrorMsg` / `markContactedErrorMsg` computed, Confirm button gated on error/empty.
+
+---
+
+## Files touched
+
+**New files (untracked):**
+- `Bold_Vision_CRM/src/utils/validators.js`
+- `Bold_Vision_CRM/src/utils/inputFilters.js`
+- `Bold_Vision_CRM/src/composables/useFeedback.js`
+- `Bold_Vision_CRM/src/components/base/AppSnackbar.vue`
+- `Bold_Vision_CRM/src/components/base/ConfirmDeleteDialog.vue`
+- `Bold_Vision_CRM/src/components/assessment/NAButton.vue`
+- `supabase/migrations/0012_customer_unique_contacts.sql`
+
+**Modified:** App.vue, all 7 assessment sections + view, AddCustomerDialog, CustomerDetailView, CustomersView, AddPropertyDialog, PropertiesForm, PropertiesView, PropertyDetailsView, PropertyInterestsPanel, CustomerInterestsPanel, BroadcastPanel, BaseSearchBar, KanbanCard, FollowUpsView, LoginView, all four services that take user input (customers, properties, media, assessments), assessmentStore, formatters.js, followUp.js, tokens.css, assessment-form.css. ~32 files total.
+
+---
+
+## What's NOT done
+
+The audit (`crispy-shimmying-valiant.md`) still has 90+ findings open. **No CRITICAL item beyond C13 has shipped.** Top of the next slice's pile:
+
+| ID | Item |
+|---|---|
+| C1 | `verify_jwt=true` + caller-owns-property check on `send-telegram` edge fn |
+| C2 | Telegram webhook `X-Telegram-Bot-Api-Secret-Token` validation |
+| C3 | `SET search_path = public, pg_temp` on all `SECURITY DEFINER` trigger functions |
+| C4 | UNIQUE on `customers.telegram_chat_id` (Slice 1 only did phone + email) |
+| C6 | `vite.config.js`: `base: '/'` |
+| C7 | `vercel.json` (SPA rewrite + CSP + security headers) |
+| C8 | `useAuthStore().init()` error handling — no infinite loading |
+| C9 | `vueDevTools` dev-only |
+| C10/C11 | Broadcast idempotency key + server-side recipient computation |
+| C12 | `await authStore.init()` before mount; use store in router guard |
+| C14 | Backup / DR plan (Supabase Pro + weekly `pg_dump` mirror) |
+| C15 | (rolled into C7) |
+
+After CRITICAL: 34 HIGH, 40 MEDIUM, 16 LOW. **Next migration is `0013_*.sql`** (0012 is taken).
+
+---
+
+## Continuing this work
+
+1. **Decide branch strategy first.**
+   - Option A: merge `Feature/Phase8-InputValidation` to main now, branch new slice off main.
+   - Option B: keep extending this branch with Slice 2 (less safe — PR keeps growing).
+   - Slice 1 + 1b is a clean reviewable PR as-is. Recommend Option A.
+
+2. **Commit before moving on.** Working tree is dirty across ~32 files. Suggested commits:
+   - `Phase 8 Slice 1: input validation across all forms + duplicate-detection + delete dialogs`
+   - `Phase 8 Slice 1b: assessment N/A flags + three-state completion logic`
+   - `Phase 8 deep-scan: LoginView email rule + search-bar maxlength + FollowUps inline errors`
+
+3. **Open PR manually on GitHub** (per [[no-gh-cli]] memory — `gh` CLI doesn't work on this machine).
+
+4. **For the next slice**, re-read the audit doc and pick a focused scope. Edge-fn auth (C1+C2) is a self-contained slice and the highest security value. Vercel deploy (C6+C7+C9+C12) is another self-contained slice but interacts with hosting setup.
+
+---
+
+## Test plan (for reviewing this PR locally)
+
+Quick smoke tests for Slice 1 + 1b:
+
+- **AddCustomerDialog**: try saving with no name → blocked; same phone as existing customer → blocked with link to that customer; same name only → yellow warn "Save anyway"; long notes (>5000) → blocked.
+- **CustomerDetailView**: open existing customer; type `abc` in phone → red inline error on blur; try delete → typed `CONFIRM` gate.
+- **PropertiesForm**: bedrooms=999 → blocked; postcode=abc → blocked; price max < min → blocked.
+- **Assessment form**: open a draft; nav rail shows correct three states as you fill fields; click N/A on Income row → row clears + locks; tick Liabilities "No liabilities" → section turns green and rows hide.
+- **Broadcast**: paste 5000-char body → cuts at 4096 with red counter; send to 0 eligible → blocked.
+- **FollowUps reschedule**: pick yesterday → inline red error; Confirm disabled.
+- **LoginView**: type `abc` in email → Vuetify rule fires "Invalid email format" on submit.
+- **Search bars**: paste 500 chars → truncated to 200.
+
+For the migration: apply `0012_customer_unique_contacts.sql` to a fresh Supabase project, verify the two partial UNIQUE indexes exist on `customers (auth_user_id, normalized phone)` and `customers (auth_user_id, lower email)`. Pre-flight SELECTs in the file should return 0 rows on a clean DB.

--- a/docs/PHASE8-HANDOFF.md
+++ b/docs/PHASE8-HANDOFF.md
@@ -1,7 +1,10 @@
-# Phase 8 Handoff — Input Validation Slice (Slice 1 + 1b)
+# Phase 8 Handoff — Slices 1, 1b, 2
 
-**Branch:** `Feature/Phase8-InputValidation` (off `main` at `8d04305`)
-**State:** Working tree dirty with Slice 1 + 1b changes. **Not committed, not merged.**
+**Branch:** `Feature/Phase8-InputValidation` (off `main` at `8d04305`) — **not yet merged**
+**Commits:**
+- `d5f1a93` — Phase 8 Slice 2: edge function security + idempotent broadcasts
+- `25af33b` — Phase 8 Slice 1: input validation across forms + assessment N/A flags
+
 **Date:** 2026-05-18
 **Full audit:** [`C:\Users\limsa\.claude\plans\crispy-shimmying-valiant.md`](../../Users/limsa/.claude/plans/crispy-shimmying-valiant.md)
 
@@ -62,11 +65,36 @@ A second-pass Explore agent audited every input across the app for missed valida
 - **Customer + Property interest pickers** `maxlength="200"` on internal search input.
 - **FollowUpsView reschedule + mark-followed-up dialogs** — `required` attr on date/time inputs, inline `<p class="field-error">` with reactive `rescheduleErrorMsg` / `markContactedErrorMsg` computed, Confirm button gated on error/empty.
 
+### Slice 2 — Edge function security + idempotent broadcasts (`d5f1a93`)
+
+Telegram-themed hardening. Closes audit items **C1, C2, C4, C10, C11** plus several HIGH/MEDIUM (H2, H3, H4, H15, H25, M1).
+
+| Change | Audit ID | Why |
+|---|---|---|
+| `verify_jwt = true` on `send-telegram` + JWT-derived ownership check via user-scoped Supabase client | C1 | Anyone with the URL could previously broadcast as anyone. |
+| Recipients derived server-side from `audience_filter` instead of trusting client array | C11 | Tampered client could insert wrong-category recipients. |
+| `idempotency_key` UUID per dialog session; UNIQUE per agent on `messages` | C10 | Double-clicks / network retries no longer fan out duplicates. |
+| `message_recipients (message_id, customer_id)` UNIQUE | C10 | Concurrent invocations collapse cleanly via `ON CONFLICT DO NOTHING`. |
+| Partial UNIQUE on `customers.telegram_chat_id` | C4 | Two customers can't bind same chat (was code-side only). |
+| `X-Telegram-Bot-Api-Secret-Token` verification on webhook | C2 | Anonymous `/start` calls with guessed enrollment tokens are blocked. |
+| 128-bit enrollment tokens (backfill rotates all existing) | H15 | 48-bit was borderline brute-forceable; 128-bit is cryptographic-key territory. |
+| Batched fan-out (25/batch, 1.1s pause) + per-fetch `AbortSignal.timeout(10s)` | H2/H3 | Old code did `Promise.all` over all recipients → Telegram rate-limit hits + 60s edge-fn hangs. |
+| CORS allowlist via `ALLOWED_ORIGINS` env var (was `*`) | H4 | Cross-origin phishing pages can't invoke as the user. |
+| Structured JSON logging (`level`/`messageId`/`customerId`/`ip`) | H25 | Grep-able function logs across both fns. |
+| Enum error codes (`auth`/`not_found`/`recipient_cap`/`rate_limited`/...) returned to client | M1 | Don't leak raw `e.message` to attackers. |
+| In-memory per-IP rate limit on webhook `/start` lookups (10/min) | belt-and-suspenders | Per-instance only (stateless edge fns); real defense is the 128-bit token. |
+
+**Two migrations:** `0013_telegram_hardening.sql` (UNIQUE indexes + idempotency_key + token bump) and `0014_service_role_grants.sql` (hotfix — `INSERT` on `message_recipients` + `SELECT, UPDATE` on `messages` for the new server-side recipient flow). The GRANT gap caught us on the first smoke test; lesson captured in [[feedback-edge-fn-grants]].
+
+**Client-side:** `messagesService.createBroadcast` now generates an `idempotencyKey` (pinned per dialog via a BroadcastPanel ref), drops the `customers`/`recipients` params, sends only `{ messageId, mediaUrls, captionLimit }` to the edge fn. On 23505 collision (retry path), looks up the existing message and lets the fn re-process failed recipients only.
+
+**Dashboard cutover steps** were executed during the session — see [`docs/PHASE8-SLICE2-CUTOVER.md`](PHASE8-SLICE2-CUTOVER.md) for the durable checklist + rollback plan.
+
 ---
 
 ## Files touched
 
-**New files (untracked):**
+**New files (Slice 1):**
 - `Bold_Vision_CRM/src/utils/validators.js`
 - `Bold_Vision_CRM/src/utils/inputFilters.js`
 - `Bold_Vision_CRM/src/composables/useFeedback.js`
@@ -75,48 +103,51 @@ A second-pass Explore agent audited every input across the app for missed valida
 - `Bold_Vision_CRM/src/components/assessment/NAButton.vue`
 - `supabase/migrations/0012_customer_unique_contacts.sql`
 
-**Modified:** App.vue, all 7 assessment sections + view, AddCustomerDialog, CustomerDetailView, CustomersView, AddPropertyDialog, PropertiesForm, PropertiesView, PropertyDetailsView, PropertyInterestsPanel, CustomerInterestsPanel, BroadcastPanel, BaseSearchBar, KanbanCard, FollowUpsView, LoginView, all four services that take user input (customers, properties, media, assessments), assessmentStore, formatters.js, followUp.js, tokens.css, assessment-form.css. ~32 files total.
+**Slice 1 modified:** App.vue, all 7 assessment sections + view, AddCustomerDialog, CustomerDetailView, CustomersView, AddPropertyDialog, PropertiesForm, PropertiesView, PropertyDetailsView, PropertyInterestsPanel, CustomerInterestsPanel, BroadcastPanel, BaseSearchBar, KanbanCard, FollowUpsView, LoginView, all four services that take user input (customers, properties, media, assessments), assessmentStore, formatters.js, followUp.js, tokens.css, assessment-form.css. ~32 files.
+
+**New files (Slice 2):**
+- `supabase/migrations/0013_telegram_hardening.sql`
+- `supabase/migrations/0014_service_role_grants.sql`
+- `docs/PHASE8-SLICE2-CUTOVER.md`
+
+**Slice 2 modified:** `supabase/functions/send-telegram/index.ts`, `supabase/functions/telegram-webhook/index.ts`, `messagesService.js`, `BroadcastPanel.vue`. 7 files / +1034/-190.
 
 ---
 
 ## What's NOT done
 
-The audit (`crispy-shimmying-valiant.md`) still has 90+ findings open. **No CRITICAL item beyond C13 has shipped.** Top of the next slice's pile:
+The audit (`crispy-shimmying-valiant.md`) still has ~80 findings open. Critical items closed by Slices 1+2: **C1, C2, C4, C10, C11, C13** (the last was Phase 7). Still open:
 
 | ID | Item |
 |---|---|
-| C1 | `verify_jwt=true` + caller-owns-property check on `send-telegram` edge fn |
-| C2 | Telegram webhook `X-Telegram-Bot-Api-Secret-Token` validation |
-| C3 | `SET search_path = public, pg_temp` on all `SECURITY DEFINER` trigger functions |
-| C4 | UNIQUE on `customers.telegram_chat_id` (Slice 1 only did phone + email) |
+| C3 | `SET search_path = public, pg_temp` on all `SECURITY DEFINER` trigger functions (30-min slice) |
 | C6 | `vite.config.js`: `base: '/'` |
 | C7 | `vercel.json` (SPA rewrite + CSP + security headers) |
 | C8 | `useAuthStore().init()` error handling — no infinite loading |
 | C9 | `vueDevTools` dev-only |
-| C10/C11 | Broadcast idempotency key + server-side recipient computation |
 | C12 | `await authStore.init()` before mount; use store in router guard |
 | C14 | Backup / DR plan (Supabase Pro + weekly `pg_dump` mirror) |
 | C15 | (rolled into C7) |
 
-After CRITICAL: 34 HIGH, 40 MEDIUM, 16 LOW. **Next migration is `0013_*.sql`** (0012 is taken).
+After CRITICAL: ~34 HIGH, ~40 MEDIUM, ~16 LOW. **Next migration is `0015_*.sql`** (0012/13/14 are taken).
 
 ---
 
 ## Continuing this work
 
 1. **Decide branch strategy first.**
-   - Option A: merge `Feature/Phase8-InputValidation` to main now, branch new slice off main.
-   - Option B: keep extending this branch with Slice 2 (less safe — PR keeps growing).
-   - Slice 1 + 1b is a clean reviewable PR as-is. Recommend Option A.
+   - Option A: merge `Feature/Phase8-InputValidation` to main now (two clean commits ready), branch new slice off main.
+   - Option B: keep extending this branch with Slice 3+ (PR keeps growing).
+   - Slices 1+2 are a clean reviewable PR as-is. **Recommend Option A.**
 
-2. **Commit before moving on.** Working tree is dirty across ~32 files. Suggested commits:
-   - `Phase 8 Slice 1: input validation across all forms + duplicate-detection + delete dialogs`
-   - `Phase 8 Slice 1b: assessment N/A flags + three-state completion logic`
-   - `Phase 8 deep-scan: LoginView email rule + search-bar maxlength + FollowUps inline errors`
+2. **Open PR manually on GitHub** when ready (per [[no-gh-cli]] memory — `gh` CLI doesn't work on this machine). Push the branch first.
 
-3. **Open PR manually on GitHub** (per [[no-gh-cli]] memory — `gh` CLI doesn't work on this machine).
+3. **For the next slice**, re-read the audit doc and pick a focused scope. Recommended:
+   - **Vercel deploy prep** (C6 + C7 + C9 + C12): last big chunk before production launch. Self-contained config + 2 small frontend changes.
+   - **DB hardening** (C3 + H10 FK indexes + H13 RLS tightening): small SQL-only slice if you want a quick win first.
+   - **Frontend resilience** (C8 + H5 + H6/H7 + H24): user-visible robustness.
 
-4. **For the next slice**, re-read the audit doc and pick a focused scope. Edge-fn auth (C1+C2) is a self-contained slice and the highest security value. Vercel deploy (C6+C7+C9+C12) is another self-contained slice but interacts with hosting setup.
+4. **Lesson from Slice 2:** when an edge-fn rewrite changes what tables it reads/writes, audit `service_role` GRANTs in a fresh migration BEFORE deploying. See [[feedback-edge-fn-grants]].
 
 ---
 
@@ -133,4 +164,6 @@ Quick smoke tests for Slice 1 + 1b:
 - **LoginView**: type `abc` in email → Vuetify rule fires "Invalid email format" on submit.
 - **Search bars**: paste 500 chars → truncated to 200.
 
-For the migration: apply `0012_customer_unique_contacts.sql` to a fresh Supabase project, verify the two partial UNIQUE indexes exist on `customers (auth_user_id, normalized phone)` and `customers (auth_user_id, lower email)`. Pre-flight SELECTs in the file should return 0 rows on a clean DB.
+Slice 2 smoke tests are in [`PHASE8-SLICE2-CUTOVER.md`](PHASE8-SLICE2-CUTOVER.md) §6 — covers anon-call-rejected, missing-secret-rejected, wrong-secret-rejected, authenticated-broadcast-works, idempotency, enrollment, already-enrolled, bad-token, structured-logs. All 9 passed in the session.
+
+For the migrations on a fresh Supabase project, apply in order: `0012_customer_unique_contacts.sql` (Slice 1 — pre-flight + functional UNIQUE indexes), then `0013_telegram_hardening.sql` (Slice 2 — UNIQUE + idempotency + token bump), then `0014_service_role_grants.sql` (Slice 2 hotfix — grants for new edge-fn flow). Each has pre-flight SELECTs or is idempotent.

--- a/docs/PHASE8-SLICE2-CUTOVER.md
+++ b/docs/PHASE8-SLICE2-CUTOVER.md
@@ -1,0 +1,233 @@
+# Phase 8 Slice 2 — Telegram security cutover
+
+Execute these in order. Each step is independently testable. **Don't skip the smoke tests at the end** — they prove the new posture is in place.
+
+**Project ref:** `cvwlrsjxgegwwptkdlma`
+**Supabase Dashboard URL:** https://supabase.com/dashboard/project/cvwlrsjxgegwwptkdlma
+
+---
+
+## Prerequisite — already done
+
+- [x] Migration `0013_telegram_hardening.sql` applied in SQL editor.
+
+---
+
+## Step 1 — Set 2 env vars
+
+**Dashboard → Project Settings → Edge Functions → Secrets** → **Add new secret** for each:
+
+### `TELEGRAM_WEBHOOK_SECRET`
+A 64-char hex string. Use this generated value (or generate your own — see note below):
+
+```
+8882426c0b18cba392f321905f5c0ae81b0110624b7cc570b739383350decae8
+```
+
+**Important:** Copy this exact value. You'll paste it into Telegram's `setWebhook` call in Step 5 — they MUST match.
+
+**To regenerate** (if you prefer your own):
+- PowerShell: `-join (1..32 | %{ '{0:x2}' -f (Get-Random -Max 256) })`
+- Bash: `openssl rand -hex 32`
+
+### `ALLOWED_ORIGINS`
+For local dev:
+
+```
+http://localhost:5173
+```
+
+When you deploy to Vercel later, edit this to add the production origin (comma-separated, no spaces):
+
+```
+http://localhost:5173,https://your-vercel-domain.vercel.app
+```
+
+---
+
+## Step 2 — Deploy `send-telegram`
+
+1. **Dashboard → Edge Functions → `send-telegram` → Edit Function**.
+2. Open the local file `supabase/functions/send-telegram/index.ts`, **select all + copy**.
+3. Paste into the Dashboard editor, replacing everything.
+4. Click **Deploy**.
+5. Watch the deploy log for any module-load errors (a missing env var will show as `TELEGRAM_BOT_TOKEN env var missing` etc. — fix the secret and redeploy).
+
+---
+
+## Step 3 — Toggle `Verify JWT` ON for `send-telegram`
+
+1. **Dashboard → Edge Functions → `send-telegram` → Settings (gear icon).**
+2. Find **Verify JWT with legacy secret** (or just "Verify JWT") and toggle it **ON**.
+3. Save.
+
+**Result:** anonymous calls now get rejected by the Supabase gateway before your function runs. The function code's own auth check is the second layer.
+
+**Don't toggle this on for `telegram-webhook`** — it must stay OFF (Telegram doesn't send Supabase JWTs).
+
+---
+
+## Step 4 — Deploy `telegram-webhook`
+
+1. **Dashboard → Edge Functions → `telegram-webhook` → Edit Function**.
+2. Copy `supabase/functions/telegram-webhook/index.ts`, paste, Deploy.
+3. Verify `Verify JWT` is OFF for this one.
+
+---
+
+## Step 5 — Re-register the Telegram webhook with `secret_token`
+
+This is the step that tells Telegram to start sending the `X-Telegram-Bot-Api-Secret-Token` header with the secret you set in Step 1.
+
+**Replace `<BOT_TOKEN>` with your Telegram bot token** (find it in your Supabase Edge Function secrets — it's `TELEGRAM_BOT_TOKEN`).
+
+### PowerShell one-liner
+
+```powershell
+$body = @{
+  url = "https://cvwlrsjxgegwwptkdlma.supabase.co/functions/v1/telegram-webhook"
+  secret_token = "8882426c0b18cba392f321905f5c0ae81b0110624b7cc570b739383350decae8"
+} | ConvertTo-Json
+Invoke-RestMethod -Uri "https://api.telegram.org/bot<BOT_TOKEN>/setWebhook" -Method Post -ContentType "application/json" -Body $body
+```
+
+### Or curl (Git Bash / WSL)
+
+**Important — Git Bash gotcha:** multi-line curls with backslash continuations + `-s` (silent) reliably hang or swallow output on MinGW64. Use the **one-line + write-to-file** pattern below. It always shows the response.
+
+**Set the webhook:**
+
+```bash
+curl -o resp.json -X POST "https://api.telegram.org/bot<BOT_TOKEN>/setWebhook" -H "Content-Type: application/json" -d '{"url":"https://cvwlrsjxgegwwptkdlma.supabase.co/functions/v1/telegram-webhook","secret_token":"8882426c0b18cba392f321905f5c0ae81b0110624b7cc570b739383350decae8"}'; cat resp.json; echo; rm resp.json
+```
+
+**Expected response:**
+
+```json
+{"ok":true,"result":true,"description":"Webhook was set"}
+```
+
+A response of `{"ok":true,"result":true,"description":"Webhook is already set"}` is **also fine** — it means the URL + secret + cert combo matches what's already configured (nothing to change).
+
+**Verify it took:**
+
+```bash
+curl -o info.json "https://api.telegram.org/bot<BOT_TOKEN>/getWebhookInfo"; cat info.json; echo; rm info.json
+```
+
+Look for in the JSON output:
+- `"url":"https://cvwlrsjxgegwwptkdlma.supabase.co/functions/v1/telegram-webhook"` ← confirms it points at YOUR function
+- `"has_custom_certificate":false`
+- `"pending_update_count":0` (or a small number)
+- **No** `"last_error_date"` / `"last_error_message"` fields. If those exist, that's Telegram telling you it couldn't deliver the last update — common cause: the webhook fn is returning a non-200 (e.g. wrong secret env var, code error).
+
+The response won't echo the secret (Telegram never reveals it back) but you'll see the URL is set.
+
+---
+
+## Step 6 — Smoke tests
+
+Run all of these. Anything red here means stop and diagnose before claiming Slice 2 done.
+
+All three curl-based smoke tests use the **one-line, write-to-file** pattern (same gotcha as Step 5 — multi-line `\` curls don't work reliably in MinGW64 Git Bash). The `-w "\nHTTP %{http_code}\n"` prints the status code on its own line at the end so you can see it without `-i`.
+
+### 6.1 — Anonymous call to `send-telegram` is rejected
+
+```bash
+curl -o resp.txt -w "\nHTTP %{http_code}\n" -X POST "https://cvwlrsjxgegwwptkdlma.supabase.co/functions/v1/send-telegram" -H "Content-Type: application/json" -d '{"messageId":"00000000-0000-0000-0000-000000000000"}'; cat resp.txt; echo; rm resp.txt
+```
+
+**Expected:** `HTTP 401` from Supabase gateway (because Verify JWT is now ON). Body will mention `Missing authorization header` or similar.
+
+### 6.2 — Webhook without secret header is rejected
+
+```bash
+curl -o resp.txt -w "\nHTTP %{http_code}\n" -X POST "https://cvwlrsjxgegwwptkdlma.supabase.co/functions/v1/telegram-webhook" -H "Content-Type: application/json" -d '{}'; cat resp.txt; echo; rm resp.txt
+```
+
+**Expected:** `HTTP 401`, body `unauthorized`.
+
+### 6.3 — Webhook with wrong secret is rejected
+
+```bash
+curl -o resp.txt -w "\nHTTP %{http_code}\n" -X POST "https://cvwlrsjxgegwwptkdlma.supabase.co/functions/v1/telegram-webhook" -H "X-Telegram-Bot-Api-Secret-Token: wrongsecret" -H "Content-Type: application/json" -d '{}'; cat resp.txt; echo; rm resp.txt
+```
+
+**Expected:** `HTTP 401`, body `unauthorized`.
+
+### 6.4 — Authenticated broadcast still works
+
+In the app:
+
+1. Sign in
+2. Open a Property detail → Broadcast
+3. Pick "All" audience
+4. Confirm a non-zero recipient count is shown
+5. Click **Send**
+6. **Expected:** "Sent to N customers" toast. The N value matches what was shown pre-send. Check Telegram on a test customer's account — message arrives.
+
+### 6.5 — Double-click doesn't double-broadcast (idempotency)
+
+In the app:
+
+1. Open Broadcast for the same property (fresh dialog).
+2. Open browser devtools → Network tab.
+3. Click **Send** TWICE rapidly (within the disabled-button window if you can).
+4. **Expected:** Test customer receives the message **once**, not twice. The Network tab may show one or two `send-telegram` invocations, but both share the same `idempotencyKey`. The second one (if it lands) finds `status='sent'` rows and reports `sent: 0`.
+
+### 6.6 — Webhook enrollment still works
+
+1. Pick a customer who has not yet enrolled (find one in your DB or create a test customer with `telegram_chat_id IS NULL`).
+2. Click the **Telegram invite link** on their Customer detail page.
+3. Inside Telegram, click **Start** on the bot.
+4. **Expected:** Bot replies "You're now enrolled, {name}!" and the customer row's `telegram_chat_id` is populated.
+
+### 6.7 — Second `/start` with same token shows correct message
+
+In the same Telegram chat that just enrolled, send `/start <same-token>` again.
+
+**Expected:** Bot replies "You're already enrolled, {name}!"
+
+### 6.8 — `/start` with bad token
+
+Send `/start abc123` (invalid token).
+
+**Expected:** Bot replies "Invalid enrollment code. Please ask your agent for a new link."
+
+### 6.9 — Function logs show structured output
+
+**Dashboard → Edge Functions → `send-telegram` → Logs**.
+
+After triggering the broadcast in 6.4, you should see JSON log lines like:
+
+```json
+{"ts":"2026-05-18T...","level":"info","fn":"send-telegram","message":"broadcast start","messageId":"...","pending":5,"hasMedia":false}
+{"ts":"2026-05-18T...","level":"info","fn":"send-telegram","message":"broadcast done","messageId":"...","sent":5,"failed":0}
+```
+
+Same for `telegram-webhook` after enrollment in 6.6.
+
+---
+
+## Rollback plan
+
+If something goes wrong after Steps 1-4 and broadcasts break for the agent:
+
+1. **Dashboard → Edge Functions → `send-telegram` → Settings**: toggle **Verify JWT** back **OFF**.
+2. Paste the OLD function code (find it in git history: `git show 25af33b:supabase/functions/send-telegram/index.ts`).
+3. Re-deploy.
+4. For the webhook: `git show 25af33b:supabase/functions/telegram-webhook/index.ts`, paste, Deploy.
+5. Re-run `setWebhook` WITHOUT the `secret_token` field (Telegram will revert to no header).
+
+The migration `0013` itself is non-destructive (adds columns + indexes; doesn't drop anything) and doesn't need to be rolled back.
+
+---
+
+## After the cutover
+
+- [ ] Mark Slice 2 done in `[[deferred-work]]` memory
+- [ ] Update `[[phase8-slice1-handoff]]` (or rename to slice2 if we keep going)
+- [ ] Commit the Slice 2 code (`Phase 8 Slice 2: edge function security`) on this branch
+- [ ] Decide: merge `Feature/Phase8-InputValidation` to main now, or keep going into Slice 3 (Vercel deploy prep)?
+
+The recommended next slice after this lands is **Vercel deploy prep** (C6 + C7 + C9 + C12) — last big chunk before the app can go to production.

--- a/supabase/functions/send-telegram/index.ts
+++ b/supabase/functions/send-telegram/index.ts
@@ -1,150 +1,400 @@
-// @ts-nocheck — this file runs on Deno (Supabase Edge Functions). The Deno
-// global + URL imports below aren't recognised by VS Code's built-in TS
-// server. Disabling type-checking here is the standard Supabase workaround;
-// runtime correctness is unaffected.
+// @ts-nocheck — runs on Deno (Supabase Edge Functions). The Deno global +
+// URL imports below aren't recognised by VS Code's built-in TS server.
+// Standard Supabase workaround; runtime correctness is unaffected.
+//
+// ─────────────────────────────────────────────────────────────────────────────
+// Phase 8 Slice 2 — Telegram broadcast hardening
+//
+// This function is callable from the Bold Vision CRM frontend to dispatch a
+// previously-created `messages` row to its queued `message_recipients`.
+//
+// Security model:
+// 1. `verify_jwt = true` is set in Supabase Dashboard for this function, so
+//    the gateway rejects anonymous calls before they even reach this code.
+// 2. We pull the caller's JWT from the Authorization header and build a
+//    user-scoped Supabase client. RLS then enforces that the caller can only
+//    read messages + recipients they own.
+// 3. We DO NOT trust any recipient list from the request body. The client
+//    sends only `messageId` (+ media URLs). We derive recipients server-side
+//    from `message_recipients` rows that the client created under RLS.
+// 4. Idempotency: recipients already marked `status='sent'` are skipped, so
+//    retrying the same broadcast (double-click, network blip) only resends
+//    the previously-failed ones.
+// 5. CORS is restricted to an env-configured allowlist instead of `*`.
+//
+// Operational safeguards:
+// - Per-fetch timeout (10s) prevents the whole function from hanging when
+//   Telegram is slow.
+// - Recipients sent in batches of 25 with a 1.1s pause between batches to
+//   respect Telegram's ~30 msg/sec global rate limit.
+// - Errors are mapped to an enum of public codes (auth / not_found /
+//   recipient_cap / rate_limited / telegram_unreachable / internal) so we
+//   don't leak internal details to a malicious caller. Structured JSON
+//   logging on the server side preserves the raw cause for debugging.
+// ─────────────────────────────────────────────────────────────────────────────
+
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
 
-const TELEGRAM_API = `https://api.telegram.org/bot${Deno.env.get('TELEGRAM_BOT_TOKEN')}`
-const SUPABASE_URL = Deno.env.get('SUPABASE_URL')!
-const SERVICE_KEY  = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!
+// ── Env wiring ──────────────────────────────────────────────────────────────
+const SUPABASE_URL  = Deno.env.get('SUPABASE_URL')
+const SERVICE_KEY   = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')
+const ANON_KEY      = Deno.env.get('SUPABASE_ANON_KEY')
+const BOT_TOKEN     = Deno.env.get('TELEGRAM_BOT_TOKEN')
+// Comma-separated origins, e.g. "http://localhost:5173,https://crm.example.com"
+const ALLOWED_ORIGINS = (Deno.env.get('ALLOWED_ORIGINS') || '')
+  .split(',').map((s) => s.trim()).filter(Boolean)
 
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+// Fail loudly at module load if any required env is missing — much easier to
+// diagnose than a runtime null-deref deep inside the handler.
+if (!SUPABASE_URL)  throw new Error('SUPABASE_URL env var missing')
+if (!SERVICE_KEY)   throw new Error('SUPABASE_SERVICE_ROLE_KEY env var missing')
+if (!ANON_KEY)      throw new Error('SUPABASE_ANON_KEY env var missing')
+if (!BOT_TOKEN)     throw new Error('TELEGRAM_BOT_TOKEN env var missing')
+
+const TELEGRAM_API = `https://api.telegram.org/bot${BOT_TOKEN}`
+
+// ── Tunables ────────────────────────────────────────────────────────────────
+const DEFAULT_CAPTION_LIMIT = 1024     // Telegram cap on media-album captions
+const RECIPIENT_CAP         = 200      // Mirror of client LIMITS.recipientCap.max
+const BATCH_SIZE            = 25       // Recipients per fan-out batch
+const BATCH_PAUSE_MS        = 1100     // Pause between batches (~30 msg/sec global limit)
+const TELEGRAM_TIMEOUT_MS   = 10_000   // Per-fetch timeout to prevent hangs
+
+// ── CORS helpers ────────────────────────────────────────────────────────────
+function corsHeaders(req: Request): Record<string, string> {
+  const origin = req.headers.get('Origin') || ''
+  // Echo the origin back if it's allowlisted, otherwise omit the header so
+  // the browser blocks the response.
+  const allowOrigin = ALLOWED_ORIGINS.includes(origin) ? origin : ''
+  return {
+    'Access-Control-Allow-Origin':  allowOrigin,
+    'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+    'Access-Control-Allow-Methods': 'POST, OPTIONS',
+    Vary: 'Origin',
+  }
 }
 
-const DEFAULT_CAPTION_LIMIT = 1024
-
-interface Recipient {
-  recipientId: string
-  customerId: string
-  telegramChatId: string
-  body: string
+function json(req: Request, payload: unknown, status = 200) {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: { ...corsHeaders(req), 'Content-Type': 'application/json' },
+  })
 }
 
-interface RequestBody {
-  messageId: string
-  recipients: Recipient[]
-  mediaUrls?: string[]
-  captionLimit?: number
+function jsonError(req: Request, code: string, status: number) {
+  return json(req, { ok: false, error: code }, status)
 }
 
+// ── Structured log helper ───────────────────────────────────────────────────
+// One JSON object per line, filterable in Supabase Function Logs by any field.
+function log(level: 'info' | 'warn' | 'error', message: string, extra: Record<string, unknown> = {}) {
+  console.log(JSON.stringify({
+    ts: new Date().toISOString(),
+    level,
+    fn: 'send-telegram',
+    message,
+    ...extra,
+  }))
+}
+
+// ── Telegram error mapping ──────────────────────────────────────────────────
+// Map Telegram API errors to one of our public codes. We log the raw error
+// server-side but only show the enum to callers.
+function mapTelegramError(data: { description?: string; error_code?: number }): string {
+  const code = data.error_code
+  if (code === 429) return 'rate_limited'
+  if (code === 403) return 'blocked_by_user'      // user blocked the bot
+  if (code === 400) return 'invalid_chat'         // chat doesn't exist / wrong id
+  return 'telegram_error'
+}
+
+// ── Main handler ────────────────────────────────────────────────────────────
 serve(async (req) => {
   if (req.method === 'OPTIONS') {
-    return new Response(null, { headers: corsHeaders })
+    return new Response(null, { headers: corsHeaders(req) })
+  }
+  if (req.method !== 'POST') {
+    return jsonError(req, 'method_not_allowed', 405)
+  }
+
+  // The Authorization header carries the caller's JWT. With verify_jwt=true
+  // in Dashboard the gateway already rejected missing/invalid tokens before
+  // we got here — but we still need the raw string to build a user-scoped
+  // client below.
+  const authHeader = req.headers.get('Authorization') || ''
+  if (!authHeader.startsWith('Bearer ')) {
+    return jsonError(req, 'auth', 401)
+  }
+  const jwt = authHeader.slice(7)
+
+  let payload: { messageId?: string; mediaUrls?: string[]; captionLimit?: number }
+  try {
+    payload = await req.json()
+  } catch {
+    return jsonError(req, 'bad_request', 400)
+  }
+  const { messageId, mediaUrls = [], captionLimit = DEFAULT_CAPTION_LIMIT } = payload
+  if (!messageId || typeof messageId !== 'string') {
+    return jsonError(req, 'bad_request', 400)
+  }
+
+  // User-scoped client: RLS applies. Used for reads where the policy must
+  // confirm the caller owns the data (message + recipients).
+  const userClient = createClient(SUPABASE_URL, ANON_KEY, {
+    global: { headers: { Authorization: `Bearer ${jwt}` } },
+    auth: { persistSession: false },
+  })
+
+  // Service-role client: bypasses RLS. Used ONLY for the recipient-row
+  // status UPDATE after we've verified ownership above. Required because
+  // status writes happen in an async batch loop and re-checking RLS on
+  // every row would be wasted work — ownership is established once at the
+  // top of the request.
+  const adminClient = createClient(SUPABASE_URL, SERVICE_KEY, {
+    auth: { persistSession: false },
+  })
+
+  // 1. Ownership check — read the message via the user-scoped client. RLS
+  //    blocks rows not owned by the caller, so a 0-row result == "not yours."
+  //    audience_filter drives the server-side recipient derivation below.
+  const { data: message, error: msgErr } = await userClient
+    .from('messages')
+    .select('id, body, audience_filter')
+    .eq('id', messageId)
+    .maybeSingle()
+  if (msgErr) {
+    log('error', 'message lookup failed', { messageId, err: msgErr.message })
+    return jsonError(req, 'internal', 500)
+  }
+  if (!message) {
+    log('warn', 'message not found or not owned by caller', { messageId })
+    return jsonError(req, 'not_found', 404)
+  }
+
+  // 2. Recipients (audit C11). The TRUTH is: a client must never pick the
+  //    target customer list itself — it picks an audience filter, and the
+  //    server expands that filter into recipient rows.
+  //
+  //    Two paths:
+  //    a) First call — no message_recipients rows yet. Query the caller's
+  //       customers via RLS (auth-scoped userClient), filter by audience +
+  //       presence of telegram_chat_id, INSERT one queued row per customer.
+  //       The (message_id, customer_id) UNIQUE from migration 0013 means a
+  //       race with a concurrent call collapses cleanly.
+  //    b) Retry call — rows exist. Read them; skip any with status='sent'
+  //       so we resend only the failed/queued ones (audit C10 idempotency).
+  //
+  //    Either way we end up with a `recipients` array to dispatch.
+  const { data: existing, error: existingErr } = await userClient
+    .from('message_recipients')
+    .select('id, customer_id, telegram_chat_id, status')
+    .eq('message_id', messageId)
+  if (existingErr) {
+    log('error', 'recipient lookup failed', { messageId, err: existingErr.message })
+    return jsonError(req, 'internal', 500)
+  }
+
+  let recipients: Array<{ id: string; customer_id: string; telegram_chat_id: string | null; status: string }>
+  if (existing && existing.length > 0) {
+    // Retry path — use what's there.
+    recipients = existing.filter((r) => r.status !== 'sent')
+    log('info', 'retry path', { messageId, existing: existing.length, toSend: recipients.length })
+  } else {
+    // First call — derive from audience filter via RLS-scoped customer query.
+    let q = userClient
+      .from('customers')
+      .select('id, telegram_chat_id')
+      .not('telegram_chat_id', 'is', null)
+    const audience = message.audience_filter
+    if (audience && audience !== 'All') {
+      q = q.eq('category', audience)
+    }
+    const { data: targetCustomers, error: custErr } = await q
+    if (custErr) {
+      log('error', 'customer derivation failed', { messageId, err: custErr.message })
+      return jsonError(req, 'internal', 500)
+    }
+    if (!targetCustomers || targetCustomers.length === 0) {
+      log('info', 'no eligible customers', { messageId, audience })
+      return json(req, { ok: true, sent: 0, failed: 0, skipped: 0, results: [] })
+    }
+    if (targetCustomers.length > RECIPIENT_CAP) {
+      log('warn', 'recipient cap exceeded', { messageId, count: targetCustomers.length })
+      return jsonError(req, 'recipient_cap', 400)
+    }
+
+    // Insert via admin client (service role bypasses RLS) — ownership was
+    // established by the message lookup above. ON CONFLICT DO NOTHING covers
+    // the rare case where two concurrent invocations race past the message
+    // lookup and both try to insert.
+    const insertRows = targetCustomers.map((c) => ({
+      message_id: messageId,
+      customer_id: c.id,
+      telegram_chat_id: c.telegram_chat_id,
+      status: 'queued',
+    }))
+    const { data: inserted, error: insertErr } = await adminClient
+      .from('message_recipients')
+      .upsert(insertRows, {
+        onConflict: 'message_id,customer_id',
+        ignoreDuplicates: true,
+      })
+      .select('id, customer_id, telegram_chat_id, status')
+    if (insertErr) {
+      log('error', 'recipient insert failed', { messageId, err: insertErr.message })
+      return jsonError(req, 'internal', 500)
+    }
+    recipients = (inserted ?? []).filter((r) => r.status !== 'sent')
+    log('info', 'derived recipients', { messageId, audience, count: recipients.length })
+
+    // Backfill recipient_count on the message for the history view.
+    await adminClient
+      .from('messages')
+      .update({ recipient_count: recipients.length })
+      .eq('id', messageId)
+  }
+
+  if (recipients.length === 0) {
+    log('info', 'nothing to send', { messageId, reason: 'all_sent_or_no_recipients' })
+    return json(req, { ok: true, sent: 0, failed: 0, skipped: 0, results: [] })
+  }
+
+  log('info', 'broadcast start', {
+    messageId,
+    pending: recipients.length,
+    hasMedia: mediaUrls.length > 0,
+  })
+
+  // 3. Batched fan-out. Telegram global cap is ~30 msg/sec — sending 25 in
+  //    parallel then pausing 1.1s keeps us comfortably under.
+  const results: Array<{ customerId: string; status: 'sent' | 'failed'; error: string | null }> = []
+  for (let i = 0; i < recipients.length; i += BATCH_SIZE) {
+    const batch = recipients.slice(i, i + BATCH_SIZE)
+    const batchResults = await Promise.all(
+      batch.map((r) => sendOne(r, message.body, mediaUrls, captionLimit, adminClient)),
+    )
+    results.push(...batchResults)
+    // Don't pause after the last batch.
+    if (i + BATCH_SIZE < recipients.length) {
+      await new Promise((r) => setTimeout(r, BATCH_PAUSE_MS))
+    }
+  }
+
+  const sent   = results.filter((r) => r.status === 'sent').length
+  const failed = results.filter((r) => r.status === 'failed').length
+  log('info', 'broadcast done', { messageId, sent, failed })
+
+  return json(req, { ok: true, sent, failed, results })
+})
+
+// ── Per-recipient send ──────────────────────────────────────────────────────
+// Returns one result row + updates the recipient's status in the DB. All
+// network calls have a 10s timeout; an AbortError gets mapped to a `timeout`
+// status so the agent can retry just the failed ones later.
+async function sendOne(
+  r: { id: string; customer_id: string; telegram_chat_id: string | null },
+  body: string,
+  mediaUrls: string[],
+  captionLimit: number,
+  adminClient: ReturnType<typeof createClient>,
+) {
+  const chatId = r.telegram_chat_id
+  if (!chatId) {
+    await adminClient.from('message_recipients').update({
+      status: 'failed', error: 'no_chat_id',
+    }).eq('id', r.id)
+    return { customerId: r.customer_id, status: 'failed' as const, error: 'no_chat_id' }
   }
 
   try {
-    const { messageId: _messageId, recipients, mediaUrls = [], captionLimit = DEFAULT_CAPTION_LIMIT } =
-      (await req.json()) as RequestBody
-
-    const supabase = createClient(SUPABASE_URL, SERVICE_KEY)
     const hasMedia = mediaUrls.length > 0
+    let ok = false
+    let errorMsg: string | null = null
 
-    const results = await Promise.all(
-      recipients.map(async (r) => {
-        try {
-          let ok = false
-          let errorMsg: string | null = null
+    if (hasMedia) {
+      // sendMediaGroup accepts up to 10 InputMedia items; caption goes on
+      // the first item only. Overflow caption is sent as a follow-up text.
+      const caption = body.slice(0, captionLimit)
+      const captionOverflow = body.length > captionLimit ? body.slice(captionLimit) : null
+      const media = mediaUrls.slice(0, 10).map((url, i) =>
+        i === 0 ? { type: 'photo', media: url, caption } : { type: 'photo', media: url },
+      )
 
-          if (hasMedia) {
-            // ── Send as media album with caption ───────────────────────────
-            const caption = r.body.slice(0, captionLimit)
-            const captionOverflow = r.body.length > captionLimit ? r.body.slice(captionLimit) : null
+      const albumRes = await fetch(`${TELEGRAM_API}/sendMediaGroup`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ chat_id: chatId, media }),
+        signal: AbortSignal.timeout(TELEGRAM_TIMEOUT_MS),
+      })
+      const albumData = await albumRes.json()
 
-            // sendMediaGroup accepts up to 10 InputMedia items. Caption goes
-            // on the first item; the rest are unlabeled.
-            const media = mediaUrls.slice(0, 10).map((url, i) =>
-              i === 0
-                ? { type: 'photo', media: url, caption }
-                : { type: 'photo', media: url },
-            )
-
-            const albumRes = await fetch(`${TELEGRAM_API}/sendMediaGroup`, {
-              method: 'POST',
-              headers: { 'Content-Type': 'application/json' },
-              body: JSON.stringify({ chat_id: r.telegramChatId, media }),
-            })
-            const albumData = await albumRes.json()
-
-            if (albumData.ok) {
-              ok = true
-              // Overflow caption → send as a follow-up text message
-              if (captionOverflow) {
-                await fetch(`${TELEGRAM_API}/sendMessage`, {
-                  method: 'POST',
-                  headers: { 'Content-Type': 'application/json' },
-                  body: JSON.stringify({ chat_id: r.telegramChatId, text: captionOverflow }),
-                })
-              }
-            } else {
-              // ── Media failed → fall back to text-only so the customer at
-              //    least gets the message body. Annotate the error so the
-              //    history view shows what happened.
-              const albumErr = albumData.description ?? 'sendMediaGroup failed'
-              const textRes = await fetch(`${TELEGRAM_API}/sendMessage`, {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ chat_id: r.telegramChatId, text: r.body }),
-              })
-              const textData = await textRes.json()
-              if (textData.ok) {
-                ok = true
-                errorMsg = `media-failed: ${albumErr} (text-only fallback sent)`
-              } else {
-                errorMsg = `media-failed: ${albumErr}; text-fallback-failed: ${textData.description ?? 'unknown'}`
-              }
-            }
-          } else {
-            // ── Plain text broadcast ───────────────────────────────────────
-            const res = await fetch(`${TELEGRAM_API}/sendMessage`, {
-              method: 'POST',
-              headers: { 'Content-Type': 'application/json' },
-              body: JSON.stringify({ chat_id: r.telegramChatId, text: r.body }),
-            })
-            const data = await res.json()
-            if (data.ok) {
-              ok = true
-            } else {
-              errorMsg = data.description ?? 'Unknown error'
-            }
-          }
-
-          // ── Update recipient row ─────────────────────────────────────────
-          if (ok) {
-            await supabase.from('message_recipients').update({
-              status: 'sent',
-              sent_at: new Date().toISOString(),
-              error: errorMsg,   // null if no error, or the media-fallback note
-            }).eq('id', r.recipientId)
-            return { customerId: r.customerId, status: 'sent', error: errorMsg }
-          } else {
-            await supabase.from('message_recipients').update({
-              status: 'failed',
-              error: errorMsg ?? 'Unknown error',
-            }).eq('id', r.recipientId)
-            return { customerId: r.customerId, status: 'failed', error: errorMsg }
-          }
-        } catch (e) {
-          const msg = e instanceof Error ? e.message : String(e)
-          await supabase.from('message_recipients').update({
-            status: 'failed',
-            error: msg,
-          }).eq('id', r.recipientId)
-          return { customerId: r.customerId, status: 'failed', error: msg }
+      if (albumData.ok) {
+        ok = true
+        if (captionOverflow) {
+          await fetch(`${TELEGRAM_API}/sendMessage`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ chat_id: chatId, text: captionOverflow }),
+            signal: AbortSignal.timeout(TELEGRAM_TIMEOUT_MS),
+          })
         }
-      }),
-    )
+      } else {
+        // Media failed → fall back to text-only so the customer at least
+        // gets the message body. Annotate the error so the history view
+        // shows what happened.
+        const albumErr = mapTelegramError(albumData)
+        const textRes = await fetch(`${TELEGRAM_API}/sendMessage`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ chat_id: chatId, text: body }),
+          signal: AbortSignal.timeout(TELEGRAM_TIMEOUT_MS),
+        })
+        const textData = await textRes.json()
+        if (textData.ok) {
+          ok = true
+          errorMsg = `media-failed-fallback-sent:${albumErr}`
+        } else {
+          errorMsg = `media-failed:${albumErr};text-failed:${mapTelegramError(textData)}`
+        }
+      }
+    } else {
+      const res = await fetch(`${TELEGRAM_API}/sendMessage`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ chat_id: chatId, text: body }),
+        signal: AbortSignal.timeout(TELEGRAM_TIMEOUT_MS),
+      })
+      const data = await res.json()
+      if (data.ok) ok = true
+      else errorMsg = mapTelegramError(data)
+    }
 
-    return new Response(JSON.stringify({ ok: true, results }), {
-      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
-    })
-  } catch (e) {
-    const msg = e instanceof Error ? e.message : String(e)
-    return new Response(JSON.stringify({ ok: false, error: msg }), {
-      status: 500,
-      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
-    })
+    // Persist the outcome. Service-role write — ownership was already
+    // established at the top of the request.
+    if (ok) {
+      await adminClient.from('message_recipients').update({
+        status: 'sent',
+        sent_at: new Date().toISOString(),
+        error: errorMsg,
+      }).eq('id', r.id)
+      return { customerId: r.customer_id, status: 'sent' as const, error: errorMsg }
+    } else {
+      await adminClient.from('message_recipients').update({
+        status: 'failed',
+        error: errorMsg ?? 'unknown',
+      }).eq('id', r.id)
+      return { customerId: r.customer_id, status: 'failed' as const, error: errorMsg }
+    }
+  } catch (e: any) {
+    // AbortError from AbortSignal.timeout → mark recipient as timed out so
+    // the agent can retry just this one later via the (future) Messages
+    // history "Resend failed" action.
+    const errorMsg = e?.name === 'AbortError' ? 'timeout' : 'internal'
+    log('error', 'sendOne crashed', { recipientId: r.id, errName: e?.name, errMsg: String(e?.message ?? e) })
+    await adminClient.from('message_recipients').update({
+      status: 'failed', error: errorMsg,
+    }).eq('id', r.id)
+    return { customerId: r.customer_id, status: 'failed' as const, error: errorMsg }
   }
-})
+}

--- a/supabase/functions/telegram-webhook/index.ts
+++ b/supabase/functions/telegram-webhook/index.ts
@@ -1,25 +1,125 @@
 // @ts-nocheck — runs on Deno (Supabase Edge Functions). The Deno global +
 // URL imports below aren't recognised by VS Code's built-in TS server.
 // Standard Supabase workaround; runtime correctness is unaffected.
+//
+// ─────────────────────────────────────────────────────────────────────────────
+// Phase 8 Slice 2 — Telegram webhook hardening
+//
+// Receives Update events from Telegram's Bot API. We use it for one thing:
+// new customers DM `/start <enrollment_token>` to bind their Telegram chat
+// to their CRM customer row.
+//
+// Security model:
+// 1. `verify_jwt = false` MUST stay in Dashboard for this function (Telegram
+//    won't send a Supabase JWT — it's an external service).
+// 2. Instead, we verify `X-Telegram-Bot-Api-Secret-Token` matches our
+//    `TELEGRAM_WEBHOOK_SECRET` env var. This secret is configured at the
+//    same time as the webhook URL via Telegram's `setWebhook` call; only
+//    Telegram (and us) know it. Missing/wrong header → 401.
+// 3. Rate-limit `/start <token>` lookups per source IP (best-effort,
+//    per-instance) to slow down brute-force enrollment-token guessing. The
+//    real defense is the 128-bit token entropy from migration 0013; the
+//    rate limiter is belt-and-suspenders.
+//
+// Operational safeguards:
+// - All env vars asserted at module load.
+// - Updates to customers wrapped in try/catch — the new partial UNIQUE on
+//   telegram_chat_id (migration 0013) will reject re-binding an already-
+//   used chat to a different customer. We catch that and reply with a
+//   friendly "chat already bound" message instead of a 500.
+// - Always returns 200 on successful processing (per Telegram's retry rule
+//   — a non-200 triggers a 24-hour retry loop). 401 only on auth failure.
+// ─────────────────────────────────────────────────────────────────────────────
+
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
 
-const BOT_TOKEN   = Deno.env.get('TELEGRAM_BOT_TOKEN')!
-const SUPABASE_URL = Deno.env.get('SUPABASE_URL')!
-const SERVICE_KEY  = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!
+// ── Env wiring ──────────────────────────────────────────────────────────────
+const BOT_TOKEN       = Deno.env.get('TELEGRAM_BOT_TOKEN')
+const SUPABASE_URL    = Deno.env.get('SUPABASE_URL')
+const SERVICE_KEY     = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')
+const WEBHOOK_SECRET  = Deno.env.get('TELEGRAM_WEBHOOK_SECRET')
 
-async function sendMessage(chatId: number, text: string) {
-  await fetch(`https://api.telegram.org/bot${BOT_TOKEN}/sendMessage`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ chat_id: chatId, text }),
-  })
+if (!BOT_TOKEN)      throw new Error('TELEGRAM_BOT_TOKEN env var missing')
+if (!SUPABASE_URL)   throw new Error('SUPABASE_URL env var missing')
+if (!SERVICE_KEY)    throw new Error('SUPABASE_SERVICE_ROLE_KEY env var missing')
+if (!WEBHOOK_SECRET) throw new Error('TELEGRAM_WEBHOOK_SECRET env var missing')
+
+const TELEGRAM_API = `https://api.telegram.org/bot${BOT_TOKEN}`
+
+// ── Tunables ────────────────────────────────────────────────────────────────
+const RATE_LIMIT_WINDOW_MS = 60_000   // 1 minute
+const RATE_LIMIT_MAX       = 10       // /start lookups per IP per window
+const TELEGRAM_TIMEOUT_MS  = 10_000
+
+// ── Structured log helper ───────────────────────────────────────────────────
+function log(level: 'info' | 'warn' | 'error', message: string, extra: Record<string, unknown> = {}) {
+  console.log(JSON.stringify({
+    ts: new Date().toISOString(),
+    level,
+    fn: 'telegram-webhook',
+    message,
+    ...extra,
+  }))
 }
 
+// ── Rate limiter (in-memory, per-instance) ──────────────────────────────────
+// Best-effort defense. Edge fns are stateless + short-lived so attackers
+// spread across instances bypass this. The real defense is 128-bit tokens
+// from migration 0013 — this just slows down loud brute-force attempts to
+// a single instance.
+const rateMap = new Map<string, { count: number; resetAt: number }>()
+function checkRate(ip: string): boolean {
+  const now = Date.now()
+  const entry = rateMap.get(ip)
+  if (!entry || entry.resetAt < now) {
+    rateMap.set(ip, { count: 1, resetAt: now + RATE_LIMIT_WINDOW_MS })
+    return true
+  }
+  if (entry.count >= RATE_LIMIT_MAX) return false
+  entry.count++
+  return true
+}
+
+function clientIp(req: Request): string {
+  // Supabase edge fns sit behind Cloudflare. Prefer cf-connecting-ip; fall
+  // back to the first IP in x-forwarded-for. 'unknown' if neither is set
+  // (only happens for direct localhost dev calls).
+  return req.headers.get('cf-connecting-ip')
+    ?? req.headers.get('x-forwarded-for')?.split(',')[0]?.trim()
+    ?? 'unknown'
+}
+
+// ── Telegram helper ─────────────────────────────────────────────────────────
+async function sendMessage(chatId: number, text: string) {
+  try {
+    await fetch(`${TELEGRAM_API}/sendMessage`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ chat_id: chatId, text }),
+      signal: AbortSignal.timeout(TELEGRAM_TIMEOUT_MS),
+    })
+  } catch (e: any) {
+    // Don't crash the handler if Telegram is unreachable — log + move on.
+    log('warn', 'sendMessage failed', { chatId, errName: e?.name, errMsg: String(e?.message ?? e) })
+  }
+}
+
+// ── Main handler ────────────────────────────────────────────────────────────
 serve(async (req) => {
-  // Telegram sends POST; anything else is a misconfiguration check
+  // Telegram only sends POST. Anything else is misconfig or scanning.
   if (req.method !== 'POST') {
     return new Response('ok')
+  }
+
+  // 1. Secret-token header check. Telegram sends this header on every
+  //    webhook call IF we set `secret_token` when registering the webhook
+  //    via setWebhook. Without this check, anyone with the function URL
+  //    could fake /start commands and hijack enrollment tokens.
+  const givenSecret = req.headers.get('X-Telegram-Bot-Api-Secret-Token')
+  if (givenSecret !== WEBHOOK_SECRET) {
+    log('warn', 'secret-token mismatch', { ip: clientIp(req), hasHeader: !!givenSecret })
+    return new Response('unauthorized', { status: 401 })
   }
 
   try {
@@ -28,45 +128,100 @@ serve(async (req) => {
     if (!message?.text) return new Response('ok')
 
     const chatId: number = message.chat.id
-    const text: string   = message.text.trim()
+    const text: string   = String(message.text).trim()
 
     if (!text.startsWith('/start')) return new Response('ok')
 
-    const token = text.split(' ')[1]?.trim()
+    const token = text.split(/\s+/)[1]?.trim()
 
+    // Bare /start (no token) — friendly welcome, no DB hit, no rate limit
     if (!token) {
       await sendMessage(chatId, 'Welcome to Bold Vision Properties! Contact your agent for an enrollment link.')
       return new Response('ok')
     }
 
-    const supabase = createClient(SUPABASE_URL, SERVICE_KEY)
+    // 2. Rate limit ONLY the token-lookup path. Bare /start is free.
+    const ip = clientIp(req)
+    if (!checkRate(ip)) {
+      log('warn', 'rate limit hit', { ip })
+      await sendMessage(chatId, 'Too many attempts. Please wait a minute and try again.')
+      return new Response('ok')
+    }
 
-    const { data: customer, error } = await supabase
-      .from('customers')
-      .select('id, name, telegram_chat_id')
-      .eq('telegram_enrollment_token', token)
-      .single()
-
-    if (error || !customer) {
+    // 3. Reject obviously malformed tokens before hitting the DB. After
+    //    migration 0013 all tokens are 32 hex chars (16 bytes). Old tokens
+    //    in flight before the migration are 12 chars (6 bytes) — we accept
+    //    either width so any link an agent sent right before the migration
+    //    still works for a short transition period.
+    if (!/^[0-9a-f]{12}$|^[0-9a-f]{32}$/i.test(token)) {
+      log('info', 'malformed token', { ip, length: token.length })
       await sendMessage(chatId, 'Invalid enrollment code. Please ask your agent for a new link.')
       return new Response('ok')
     }
 
-    if (customer.telegram_chat_id) {
+    const supabase = createClient(SUPABASE_URL, SERVICE_KEY, {
+      auth: { persistSession: false },
+    })
+
+    const { data: customer, error: lookupErr } = await supabase
+      .from('customers')
+      .select('id, name, telegram_chat_id')
+      .eq('telegram_enrollment_token', token)
+      .maybeSingle()
+
+    if (lookupErr) {
+      log('error', 'customer lookup failed', { errMsg: lookupErr.message })
+      await sendMessage(chatId, 'Something went wrong. Please try again or contact your agent.')
+      return new Response('ok')
+    }
+
+    if (!customer) {
+      log('info', 'token not found', { ip })
+      await sendMessage(chatId, 'Invalid enrollment code. Please ask your agent for a new link.')
+      return new Response('ok')
+    }
+
+    // Already enrolled — same customer hitting /start again. Friendly nudge.
+    if (customer.telegram_chat_id === String(chatId)) {
       await sendMessage(chatId, `You're already enrolled, ${customer.name}! You'll receive property updates here.`)
       return new Response('ok')
     }
 
-    await supabase
+    // Customer was previously bound to a different chat — block re-binding.
+    // (Edge case: agent re-issued a token to a customer who already enrolled
+    // from a different Telegram account. Force them to talk to the agent
+    // rather than silently swap.)
+    if (customer.telegram_chat_id && customer.telegram_chat_id !== String(chatId)) {
+      log('warn', 'enrollment attempt on different chat', { customerId: customer.id, ip })
+      await sendMessage(chatId, 'This enrollment link has already been used. Contact your agent for help.')
+      return new Response('ok')
+    }
+
+    // 4. Bind chat_id → customer. Wrapped in try/catch to handle the new
+    //    partial UNIQUE index from migration 0013 — if another customer
+    //    already has this chat_id, the UPDATE fails with 23505.
+    const { error: updateErr } = await supabase
       .from('customers')
       .update({ telegram_chat_id: String(chatId) })
       .eq('id', customer.id)
 
-    await sendMessage(chatId, `You're now enrolled, ${customer.name}! You'll receive property updates from Bold Vision Properties here.`)
+    if (updateErr) {
+      if (updateErr.code === '23505') {
+        log('warn', 'chat already bound to another customer', { customerId: customer.id, ip })
+        await sendMessage(chatId, 'This Telegram account is already linked to another customer. Contact your agent.')
+        return new Response('ok')
+      }
+      log('error', 'enrollment update failed', { customerId: customer.id, errMsg: updateErr.message })
+      await sendMessage(chatId, 'Something went wrong saving your enrollment. Please try again or contact your agent.')
+      return new Response('ok')
+    }
 
+    log('info', 'enrollment success', { customerId: customer.id })
+    await sendMessage(chatId, `You're now enrolled, ${customer.name}! You'll receive property updates from Bold Vision Properties here.`)
     return new Response('ok')
-  } catch (e) {
-    console.error('telegram-webhook error:', e)
-    return new Response('ok') // always 200 to Telegram to prevent retries
+  } catch (e: any) {
+    log('error', 'webhook crashed', { errName: e?.name, errMsg: String(e?.message ?? e) })
+    // Always 200 to Telegram to skip its 24-hour retry loop.
+    return new Response('ok')
   }
 })

--- a/supabase/migrations/0012_customer_unique_contacts.sql
+++ b/supabase/migrations/0012_customer_unique_contacts.sql
@@ -1,0 +1,52 @@
+-- ============================================================
+-- Phase 8 — Slice 1: Input Validation
+-- Per-agent UNIQUE constraints on customer phone + email.
+--
+-- Phone is normalized to digits-only ("0412 345 678" == "+61412345678"
+-- when stripped). Email is lower-cased so "JOHN@x.com" == "john@x.com".
+-- ============================================================
+
+-- ── PRE-FLIGHT ─────────────────────────────────────────────────
+-- Run each query in the Supabase SQL editor BEFORE the CREATE INDEX
+-- block below. If either returns rows, fix the offending customers
+-- (open one and change the phone/email or delete the duplicate)
+-- before re-running. The CREATE INDEX will FAIL if dupes exist.
+--
+-- 1. Customers sharing a phone within the same agent
+-- SELECT auth_user_id,
+--        regexp_replace(phone, '\D', '', 'g') AS phone_digits,
+--        count(*),
+--        array_agg(id) AS customer_ids,
+--        array_agg(name) AS names
+-- FROM public.customers
+-- WHERE coalesce(phone, '') <> ''
+-- GROUP BY auth_user_id, phone_digits
+-- HAVING count(*) > 1;
+--
+-- 2. Customers sharing an email within the same agent
+-- SELECT auth_user_id,
+--        lower(email) AS email_lower,
+--        count(*),
+--        array_agg(id) AS customer_ids,
+--        array_agg(name) AS names
+-- FROM public.customers
+-- WHERE coalesce(email, '') <> ''
+-- GROUP BY auth_user_id, email_lower
+-- HAVING count(*) > 1;
+
+-- ── CONSTRAINTS ────────────────────────────────────────────────
+-- Idempotent via IF NOT EXISTS. Partial indexes — only enforce
+-- uniqueness on non-blank values, so blank phone/email rows
+-- coexist freely.
+--
+-- Scope: (auth_user_id, normalized value). Two different agents
+-- can both have a customer with phone 0412 345 678; one agent
+-- can't have two.
+
+CREATE UNIQUE INDEX IF NOT EXISTS customers_unique_phone_per_agent
+  ON public.customers (auth_user_id, (regexp_replace(phone, '\D', '', 'g')))
+  WHERE coalesce(phone, '') <> '';
+
+CREATE UNIQUE INDEX IF NOT EXISTS customers_unique_email_per_agent
+  ON public.customers (auth_user_id, lower(email))
+  WHERE coalesce(email, '') <> '';

--- a/supabase/migrations/0013_telegram_hardening.sql
+++ b/supabase/migrations/0013_telegram_hardening.sql
@@ -1,0 +1,120 @@
+-- ─────────────────────────────────────────────────────────────────────────────
+-- Phase 8 Slice 2: Telegram broadcast + webhook hardening
+--
+-- DB foundation for the edge-fn security work. All changes are idempotent.
+-- Two parts:
+--   A) PRE-FLIGHT  — read-only SELECTs. Run each block alone; if it returns
+--                    ANY rows, fix manually before proceeding.
+--   B) CONSTRAINTS — only after every pre-flight returns 0 rows.
+--
+-- Apply via Supabase Dashboard SQL editor — CLI is unreliable on this machine
+-- per [[supabase-config]].
+-- ─────────────────────────────────────────────────────────────────────────────
+
+
+-- ============================================================
+-- PART A  — PRE-FLIGHT  (run each query in isolation first)
+-- ============================================================
+
+-- 1. Customers sharing a telegram_chat_id (would block the partial UNIQUE
+--    index in Part B). If this returns rows, decide which customer keeps
+--    the chat_id and NULL out the others.
+--
+-- SELECT telegram_chat_id, count(*), array_agg(id) AS customer_ids
+--   FROM public.customers
+--  WHERE telegram_chat_id IS NOT NULL
+--  GROUP BY 1
+-- HAVING count(*) > 1;
+
+-- 2. Duplicate (message_id, customer_id) in message_recipients (would block
+--    the UNIQUE constraint). Shouldn't exist in practice — current client
+--    inserts one row per recipient per message — but check anyway.
+--
+-- SELECT message_id, customer_id, count(*)
+--   FROM public.message_recipients
+--  GROUP BY 1, 2
+-- HAVING count(*) > 1;
+
+-- 3. Sanity check on existing enrollment tokens. We're about to backfill all
+--    customers to 16-byte (128-bit) tokens. If any customer is already
+--    enrolled (telegram_chat_id set), their token is irrelevant — the chat
+--    is already bound. Pre-enrollment customers' tokens will rotate, so the
+--    OLD link the agent sent them will stop working.
+--
+-- SELECT count(*) FILTER (WHERE telegram_chat_id IS NOT NULL) AS enrolled,
+--        count(*) FILTER (WHERE telegram_chat_id IS NULL)     AS pending
+--   FROM public.customers;
+
+
+-- ============================================================
+-- PART B  — CONSTRAINTS  (after every pre-flight is clean)
+-- ============================================================
+
+-- ── B1. customers.telegram_chat_id partial UNIQUE  (audit C4) ───────────────
+--
+-- Why partial? telegram_chat_id is nullable (most customers haven't enrolled).
+-- A plain UNIQUE would treat each NULL as distinct, which works in Postgres,
+-- but a partial index makes the intent explicit: "uniqueness only applies
+-- when the value is set."
+--
+-- Why per-row, not per-agent? A Telegram chat is globally unique — no two
+-- agents could legitimately bind the same chat_id to different customers
+-- (that chat is one human). Per-row UNIQUE matches reality.
+CREATE UNIQUE INDEX IF NOT EXISTS customers_telegram_chat_id_unique
+  ON public.customers (telegram_chat_id)
+  WHERE telegram_chat_id IS NOT NULL;
+
+
+-- ── B2. messages.idempotency_key + UNIQUE per agent  (audit C10) ────────────
+--
+-- The client generates a random UUID per Send-button click (NOT per retry).
+-- If the same key shows up twice for the same agent, the second insert
+-- collides — we treat that as "this broadcast was already created" and reuse
+-- the existing message row instead of duplicating.
+--
+-- Scoped per (auth_user_id) because the UUID is generated client-side; two
+-- different agents' UUIDs colliding is astronomically unlikely but the
+-- per-agent scope also enables future "retry by idempotency_key" flows that
+-- need to be auth-scoped anyway.
+ALTER TABLE public.messages
+  ADD COLUMN IF NOT EXISTS idempotency_key uuid;
+
+CREATE UNIQUE INDEX IF NOT EXISTS messages_idempotency_key_unique_per_agent
+  ON public.messages (auth_user_id, idempotency_key)
+  WHERE idempotency_key IS NOT NULL;
+
+
+-- ── B3. message_recipients (message_id, customer_id) UNIQUE  (audit C10) ────
+--
+-- Even with idempotency_key on messages, a partial server-side retry could
+-- in theory try to insert a recipient row that already exists. UNIQUE
+-- here means the edge fn can use INSERT ... ON CONFLICT DO NOTHING and rely
+-- on existing rows' status (queued/sent/failed) as the source of truth.
+ALTER TABLE public.message_recipients
+  ADD CONSTRAINT message_recipients_unique_per_message_customer
+  UNIQUE (message_id, customer_id);
+
+
+-- ── B4. Bump enrollment token entropy to 128 bits  (audit H15) ──────────────
+--
+-- 6 bytes = 48 bits. At a few thousand customers, brute-forcing a chat-hijack
+-- via the webhook is borderline feasible (especially before secret-token
+-- header verification lands in the same slice). 16 bytes = 128 bits puts it
+-- in cryptographic-key territory — infeasible regardless of how many
+-- customers exist.
+--
+-- BACKFILL behavior: every customer's token rotates to a new 128-bit value.
+-- - Already-enrolled customers (telegram_chat_id set): unaffected. The bot
+--   is keyed off chat_id, not the token, after enrollment.
+-- - Pre-enrollment customers: any OLD invite link the agent sent will stop
+--   working. The agent must re-send from the Customer detail page.
+
+-- Default for new rows
+ALTER TABLE public.customers
+  ALTER COLUMN telegram_enrollment_token SET DEFAULT encode(gen_random_bytes(16), 'hex');
+
+-- One-shot backfill of all existing rows. We rotate everyone (even enrolled
+-- customers) so the column has uniform width — keeps any future audit
+-- "find weak tokens" query trivial.
+UPDATE public.customers
+   SET telegram_enrollment_token = encode(gen_random_bytes(16), 'hex');

--- a/supabase/migrations/0014_service_role_grants.sql
+++ b/supabase/migrations/0014_service_role_grants.sql
@@ -1,0 +1,24 @@
+-- ─────────────────────────────────────────────────────────────────────────────
+-- Phase 8 Slice 2 hotfix — service_role grants for new send-telegram flow
+--
+-- The Slice 2 send-telegram rewrite moved recipient derivation server-side
+-- (audit C11). The edge fn now does two things the old one didn't:
+--   1) INSERT into message_recipients (derive from audience filter)
+--   2) UPDATE recipient_count on messages (backfill after derivation)
+--
+-- Per [[supabase-config]] this project has auto-expose disabled, so every
+-- service_role privilege must be granted explicitly. Migration 0005 only
+-- granted SELECT, UPDATE on message_recipients (the old fn only updated
+-- status). The new fn fails with `permission denied for table
+-- message_recipients` on the first invocation.
+--
+-- All idempotent — safe to re-run.
+-- ─────────────────────────────────────────────────────────────────────────────
+
+-- INSERT for the recipient-derivation upsert in send-telegram
+GRANT INSERT ON public.message_recipients TO service_role;
+
+-- SELECT + UPDATE on messages for the recipient_count backfill in send-telegram
+-- (SELECT is for safety — Supabase clients sometimes need it for upsert
+-- conflict resolution and other ops that secretly read.)
+GRANT SELECT, UPDATE ON public.messages TO service_role;

--- a/supabase/migrations/0015_security_definer_search_path.sql
+++ b/supabase/migrations/0015_security_definer_search_path.sql
@@ -1,0 +1,114 @@
+-- ─────────────────────────────────────────────────────────────────────────────
+-- Phase 8 Stage 1 — audit C3: SECURITY DEFINER hardening
+--
+-- Supabase Security Advisor flags three issues against our trigger functions:
+--
+-- 1. "Function Search Path Mutable" — applies to ANY function (not just
+--    SECURITY DEFINER) without a pinned `search_path`. A malicious schema
+--    could shadow unqualified function references like `now()` if a caller
+--    manipulated their session search_path.
+--    Fix: bake `SET search_path = public, pg_temp` into each definition.
+--
+-- 2. "Public Can Execute SECURITY DEFINER Function" — SECURITY DEFINER
+--    functions run as their owner (postgres), so a public-callable one is a
+--    privilege-escalation vector. Our 5 trigger functions are ONLY invoked
+--    by BEFORE INSERT triggers, never by user code.
+--    Fix: REVOKE EXECUTE FROM public + anon. Triggers fire regardless of
+--    EXECUTE grants (they run as the table owner).
+--
+-- 3. "Signed-In Users Can Execute SECURITY DEFINER Function" — same concern
+--    extended to the `authenticated` role.
+--    Fix: REVOKE EXECUTE FROM authenticated too.
+--
+-- Out of scope (advisor flags but not ours to fix):
+-- - `public.rls_auto_enable()` — Supabase platform function, not in our
+--   codebase. Whatever they ship as defaults is their concern.
+-- - "Leaked Password Protection Disabled" — Auth-level setting toggled in
+--   Dashboard → Authentication → Settings → Password protection. One click.
+--
+-- All idempotent via `CREATE OR REPLACE FUNCTION` + idempotent REVOKE.
+-- ─────────────────────────────────────────────────────────────────────────────
+
+create or replace function public.set_auth_user_id()
+returns trigger
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+begin
+  new.auth_user_id = auth.uid();
+  return new;
+end;
+$$;
+
+create or replace function public.set_customer_feedback_auth_user_id()
+returns trigger
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+begin
+  new.auth_user_id = auth.uid();
+  return new;
+end;
+$$;
+
+create or replace function public.set_property_interests_auth_user_id()
+returns trigger
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+begin
+  new.auth_user_id = auth.uid();
+  return new;
+end;
+$$;
+
+create or replace function public.set_messages_auth_user_id()
+returns trigger
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+begin
+  new.auth_user_id = auth.uid();
+  return new;
+end;
+$$;
+
+create or replace function public.set_customer_assessments_auth_user_id()
+returns trigger
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+begin
+  new.auth_user_id = auth.uid();
+  return new;
+end;
+$$;
+
+-- ── handle_updated_at — not SECURITY DEFINER, but flagged for mutable
+-- search_path. Pinning is cheap defense + clears the advisor warning. ────────
+create or replace function public.handle_updated_at()
+returns trigger
+language plpgsql
+set search_path = public, pg_temp
+as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+-- ── Lock down execute permissions on the 5 SECURITY DEFINER trigger
+-- functions. They're trigger-only — fired by BEFORE INSERT triggers running
+-- as the table owner. No legitimate user code path calls them directly, so
+-- there's no reason for `public`, `anon`, or `authenticated` to have EXECUTE.
+-- Revoking closes the advisor warnings + tightens privilege surface. ────────
+revoke execute on function public.set_auth_user_id()                       from public, anon, authenticated;
+revoke execute on function public.set_customer_feedback_auth_user_id()     from public, anon, authenticated;
+revoke execute on function public.set_property_interests_auth_user_id()    from public, anon, authenticated;
+revoke execute on function public.set_messages_auth_user_id()              from public, anon, authenticated;
+revoke execute on function public.set_customer_assessments_auth_user_id()  from public, anon, authenticated;


### PR DESCRIPTION
## Summary
Closes all CRITICAL items from the pre-Phase-8 audit (105 findings). V1 is now code-ready for deploy.

**Audit IDs shipped:** C1, C2, C3, C4, C6, C7, C8, C9, C10, C11, C12, C13 + H14 (open redirect). C14 (backups) auto-lands when Supabase Pro is provisioned in Phase 10.

## What's in the box (9 commits)

**Input + UX hardening**
- `25af33b` Slice 1 — input validation across forms + assessment N/A flags + three-state completion
- `d5f1a93` Slice 2 — edge function security (JWT verify on `send-telegram`, webhook secret on `telegram-webhook`) + idempotent broadcasts
- `e0268aa` Docs — extended PHASE8-HANDOFF for Slice 2

**Database (migrations 0012–0015)**
- `8c84b12` C3 — `SET search_path = public, pg_temp` on all SECURITY DEFINER functions + REVOKE EXECUTE from public/anon/authenticated

**Build + auth + deploy**
- `86f2109` C6 + C9 — vite `base: '/'` for Vercel + vueDevTools dev-only
- `ba6565e` C8 — auth init error handling with retry UI; await `authStore.init()` before mount (partial C12)
- `69c2e4b` C12 — finished store-first router guard with `getSession()` fallback that heals the store + triggers fetches (kills cold-start flash)
- `a2e7836` C7 — `vercel.json` with SPA rewrite, CSP, HSTS, X-Frame-Options DENY, Referrer-Policy, Permissions-Policy, cache headers

**Security follow-up**
- `cb693da` H14 — `safeRedirect()` on LoginView blocks `?redirect=https://evil.com` open-redirect

## What's deferred
- C14 (daily backups + 7-day PITR) → auto-lands when Supabase Pro is provisioned in Phase 10
- Leaked Password Protection toggle → Pro-only feature, enabled in Phase 10 Phase D step 7a
- ~70 HIGH/MEDIUM items are post-V1 operational hardening (not launch blockers) — tracked in the 105-finding audit doc

## Test plan
- [x] Local `npm run build` succeeds; `dist/index.html` references `/assets/*` (no `/CRM-Project/` prefix)
- [x] Cold sign-in resolves before first view renders (no login flash on refresh)
- [x] `?redirect=https://evil.com` is ignored; lands on `/`
- [x] `?redirect=/customers/123` lands on `/customers/123`
- [x] Edge fn `send-telegram` without `Authorization` → 401
- [x] Edge fn `send-telegram` invoked twice with same `message_id` → second call sends 0 (idempotent)
- [x] `telegram-webhook` without `X-Telegram-Bot-Api-Secret-Token` → 401
- [x] **Phase 9** (next): deploy to personal Vercel + run full smoke set from `docs/PHASE8-SLICE2-CUTOVER.md` §6
