### PR TITLE
Phase 8.2: allow Google Fonts in CSP

### DIFF
--- a/Bold_Vision_CRM/vercel.json
+++ b/Bold_Vision_CRM/vercel.json
@@ -17,7 +17,7 @@
         { "key": "X-Frame-Options",           "value": "DENY" },
         { "key": "Referrer-Policy",           "value": "strict-origin-when-cross-origin" },
         { "key": "Permissions-Policy",        "value": "camera=(), microphone=(), geolocation=(), payment=()" },
-        { "key": "Content-Security-Policy",   "value": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; font-src 'self' data:; img-src 'self' data: blob: https:; connect-src 'self' https://cvwlrsjxgegwwptkdlma.supabase.co wss://cvwlrsjxgegwwptkdlma.supabase.co; frame-ancestors 'none'; base-uri 'self'; form-action 'self'" }
+        { "key": "Content-Security-Policy",   "value": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' data: https://fonts.gstatic.com; img-src 'self' data: blob: https:; connect-src 'self' https://cvwlrsjxgegwwptkdlma.supabase.co wss://cvwlrsjxgegwwptkdlma.supabase.co; frame-ancestors 'none'; base-uri 'self'; form-action 'self'" }
       ]
     },
     {


### PR DESCRIPTION
typography.css @imports Geist + Instrument Serif from Google Fonts, which our P8 CSP blocked. Local dev didn't surface this because the CSP only ships via vercel.json on production.

Whitelisted:
- style-src += https://fonts.googleapis.com  (the CSS stylesheet)
- font-src  += https://fonts.gstatic.com     (the actual font files)