### PR TITLE
Phase 8.4: expand property type + status enums (AU-focused) + consoli…

### DIFF
--- a/Bold_Vision_CRM/src/components/properties/AddPropertyDialog.vue
+++ b/Bold_Vision_CRM/src/components/properties/AddPropertyDialog.vue
@@ -1,7 +1,7 @@
 <template>
   <v-dialog
     v-model="isOpen"
-    :max-width="640"
+    :max-width="704"
     transition="dialog-transition"
     :scrim="'rgba(15,23,42,0.65)'"
   >

--- a/Bold_Vision_CRM/src/components/properties/PropertiesForm.vue
+++ b/Bold_Vision_CRM/src/components/properties/PropertiesForm.vue
@@ -113,7 +113,7 @@
             <p v-if="errors.priceMin" class="field-error">{{ errors.priceMin }}</p>
           </div>
           <div class="field" :class="{ 'is-error': errors.priceMax }">
-            <label for="pf-price-max">Price (max, optional)</label>
+            <label for="pf-price-max">Price (max)</label>
             <div class="input-affix">
               <span class="prefix">$</span>
               <input
@@ -121,7 +121,7 @@
                 v-model="priceMaxInput"
                 class="input has-prefix"
                 type="text"
-                placeholder="leave blank for single price"
+                placeholder="optional"
                 autocomplete="off"
                 @input="clearError('priceMax')"
                 @blur="normalizePriceInput('max'); validateFieldNamed('priceMax')"
@@ -279,9 +279,10 @@
 import { computed, ref, watch } from 'vue'
 import { formatPrice, formatPriceSingle, parsePriceInput, formatSqm } from '../../utils/formatters'
 import { validatePropertyForm, LIMITS } from '../../utils/validators'
+import { PROPERTY_TYPES, PROPERTY_STATUSES } from '../../constants/enums'
 
-const typeOptions = ['House', 'Townhouse', 'Villa', 'Apartment']
-const statusOptions = ['On Market', 'Coming Soon', 'Under Contract', 'Sold', 'Off Market', 'Withdrawn']
+const typeOptions = PROPERTY_TYPES
+const statusOptions = PROPERTY_STATUSES
 const stateOptions = ['VIC', 'NSW', 'QLD', 'WA', 'SA', 'TAS', 'ACT', 'NT']
 
 const props = defineProps({
@@ -447,7 +448,9 @@ defineExpose({ validate })
 }
 .grid-4 {
   display: grid;
-  grid-template-columns: repeat(4, 1fr);
+  /* Type + status carry the long enum values (e.g. "10/90 One-Part Contract",
+     "Under Construction") so they get double the share of the row. */
+  grid-template-columns: 2fr 2fr 1fr 1fr;
   gap: 12px;
 }
 .grid-5 {

--- a/Bold_Vision_CRM/src/components/properties/PropertiesToolbar.vue
+++ b/Bold_Vision_CRM/src/components/properties/PropertiesToolbar.vue
@@ -84,15 +84,24 @@
 import { computed } from 'vue'
 import AppIcon from '../base/AppIcon.vue'
 import BaseFilterBar from '../base/BaseFilterBar.vue'
+import { PROPERTY_STATUSES } from '../../constants/enums'
+
+// Colour token per status. Status names come from enums.js; if a new status
+// lands without an entry here, the chip falls back to text-muted grey.
+const STATUS_DOTS = {
+  'On Market':          'var(--success)',
+  'Coming Soon':        'var(--warm)',
+  'Under Construction': 'var(--warm)',
+  'Ready Built':        'var(--success)',
+  'Under Contract':     'var(--accent)',
+  'Sold':               'var(--cold)',
+  'Off Market':         'var(--text-muted)',
+  'Withdrawn':          'var(--hot)',
+}
 
 const STATUS_GROUPS = [
-  { label: 'All',            dot: null },
-  { label: 'On Market',      dot: 'var(--success)' },
-  { label: 'Coming Soon',    dot: 'var(--warm)' },
-  { label: 'Under Contract', dot: 'var(--accent)' },
-  { label: 'Sold',           dot: 'var(--cold)' },
-  { label: 'Off Market',     dot: 'var(--text-muted)' },
-  { label: 'Withdrawn',      dot: 'var(--hot)' },
+  { label: 'All', dot: null },
+  ...PROPERTY_STATUSES.map((label) => ({ label, dot: STATUS_DOTS[label] ?? 'var(--text-muted)' })),
 ]
 
 const props = defineProps({

--- a/Bold_Vision_CRM/src/config/filterDefinitions.js
+++ b/Bold_Vision_CRM/src/config/filterDefinitions.js
@@ -1,4 +1,10 @@
-// Centralized filter configurations reused across views
+// Centralized filter configurations reused across views.
+// Property option values derive from src/constants/enums.js — single source of truth.
+
+import { PROPERTY_TYPES, PROPERTY_STATUSES } from '../constants/enums'
+
+const toOption = (v) => ({ title: v, value: v })
+
 export const propertyFilterDefinitions = [
   {
     key: 'status',
@@ -10,14 +16,7 @@ export const propertyFilterDefinitions = [
       { label: 'is', value: 'is' },
       { label: 'is not', value: 'is_not' },
     ],
-    options: [
-      { title: 'On Market',      value: 'On Market' },
-      { title: 'Coming Soon',    value: 'Coming Soon' },
-      { title: 'Under Contract', value: 'Under Contract' },
-      { title: 'Sold',           value: 'Sold' },
-      { title: 'Off Market',     value: 'Off Market' },
-      { title: 'Withdrawn',      value: 'Withdrawn' },
-    ],
+    options: PROPERTY_STATUSES.map(toOption),
   },
   {
     key: 'type',
@@ -29,12 +28,7 @@ export const propertyFilterDefinitions = [
       { label: 'is', value: 'is' },
       { label: 'is not', value: 'is_not' },
     ],
-    options: [
-      { title: 'House', value: 'House' },
-      { title: 'Townhouse', value: 'Townhouse' },
-      { title: 'Apartment', value: 'Apartment' },
-      { title: 'Villa', value: 'Villa' },
-    ],
+    options: PROPERTY_TYPES.map(toOption),
   },
 ]
 

--- a/Bold_Vision_CRM/src/constants/enums.js
+++ b/Bold_Vision_CRM/src/constants/enums.js
@@ -1,5 +1,36 @@
-export const PROPERTY_TYPES = ['House', 'Townhouse', 'Apartment', 'Villa']
-export const PROPERTY_STATUSES = ['On Market', 'Under Offer', 'Sold']
+// Single source of truth for property + customer enums.
+// Order matters — UI components render values in this order.
+
+export const PROPERTY_TYPES = [
+  'House',
+  'Townhouse',
+  'Apartment',
+  'Villa',
+  'Unit',
+  'Duplex',
+  'Studio',
+  'Penthouse',
+  'Land',
+  'Acreage / Rural',
+  'Granny Flat',
+  'Retirement Living',
+  'NDIS SDA Home',
+  'Off-the-Plan',
+  'House and Land Package',
+  '10/90 One-Part Contract',
+]
+
+export const PROPERTY_STATUSES = [
+  'On Market',
+  'Coming Soon',
+  'Under Construction',
+  'Ready Built',
+  'Under Contract',
+  'Sold',
+  'Off Market',
+  'Withdrawn',
+]
+
 export const CUSTOMER_CATEGORIES = ['Cold', 'Warm', 'Hot']
 export const CUSTOMER_CHANNELS = ['Call', 'Telegram', 'SMS', 'Email']
 export const INTEREST_LEVELS = ['Cold', 'Warm', 'Hot']

--- a/Bold_Vision_CRM/src/styles/tokens.css
+++ b/Bold_Vision_CRM/src/styles/tokens.css
@@ -368,12 +368,14 @@
   color: var(--text); box-shadow: var(--shadow-xs);
 }
 .status-badge .dot { width: 6px; height: 6px; border-radius: 50%; }
-.status-badge.on-market     { color: var(--success-ink); }  .status-badge.on-market     .dot { background: var(--success); }
-.status-badge.coming-soon   { color: var(--warm-ink); }     .status-badge.coming-soon   .dot { background: var(--warm); }
-.status-badge.under-contract{ color: var(--accent-ink); }   .status-badge.under-contract .dot { background: var(--accent); }
-.status-badge.sold          { color: var(--cold-ink); }     .status-badge.sold          .dot { background: var(--cold); }
-.status-badge.off-market    { color: var(--text-muted); }   .status-badge.off-market    .dot { background: var(--text-muted); }
-.status-badge.withdrawn     { color: var(--hot-ink); }      .status-badge.withdrawn     .dot { background: var(--hot); }
+.status-badge.on-market         { color: var(--success-ink); }  .status-badge.on-market         .dot { background: var(--success); }
+.status-badge.coming-soon       { color: var(--warm-ink); }     .status-badge.coming-soon       .dot { background: var(--warm); }
+.status-badge.under-construction{ color: var(--warm-ink); }     .status-badge.under-construction .dot { background: var(--warm); }
+.status-badge.ready-built       { color: var(--success-ink); }  .status-badge.ready-built       .dot { background: var(--success); }
+.status-badge.under-contract    { color: var(--accent-ink); }   .status-badge.under-contract    .dot { background: var(--accent); }
+.status-badge.sold              { color: var(--cold-ink); }     .status-badge.sold              .dot { background: var(--cold); }
+.status-badge.off-market        { color: var(--text-muted); }   .status-badge.off-market        .dot { background: var(--text-muted); }
+.status-badge.withdrawn         { color: var(--hot-ink); }      .status-badge.withdrawn         .dot { background: var(--hot); }
 
 /* Status chip toolbar */
 .status-chips {

--- a/Bold_Vision_CRM/src/utils/property.js
+++ b/Bold_Vision_CRM/src/utils/property.js
@@ -3,11 +3,13 @@ const DAY_MS = 24 * 60 * 60 * 1000
 export const heatOrder = { Hot: 0, Warm: 1, Cold: 2 }
 
 export function computeBadge(listedAtIso, status) {
-  if (status === 'Sold')            return { type: 'sold',           label: 'Sold',           color: 'grey-darken-1' }
-  if (status === 'Under Contract')  return { type: 'under_contract', label: 'Under contract', color: 'amber-darken-2' }
-  if (status === 'Off Market')      return { type: 'off_market',     label: 'Off market',     color: 'grey' }
-  if (status === 'Withdrawn')       return { type: 'withdrawn',      label: 'Withdrawn',      color: 'red-darken-2' }
-  if (status === 'Coming Soon')     return { type: 'coming_soon',    label: 'Coming soon',    color: 'orange-darken-1' }
+  if (status === 'Sold')               return { type: 'sold',               label: 'Sold',               color: 'grey-darken-1' }
+  if (status === 'Under Contract')     return { type: 'under_contract',     label: 'Under contract',     color: 'amber-darken-2' }
+  if (status === 'Off Market')         return { type: 'off_market',         label: 'Off market',         color: 'grey' }
+  if (status === 'Withdrawn')          return { type: 'withdrawn',          label: 'Withdrawn',          color: 'red-darken-2' }
+  if (status === 'Coming Soon')        return { type: 'coming_soon',        label: 'Coming soon',        color: 'orange-darken-1' }
+  if (status === 'Under Construction') return { type: 'under_construction', label: 'Under construction', color: 'orange-darken-1' }
+  if (status === 'Ready Built')        return { type: 'ready_built',        label: 'Ready built',        color: 'green-darken-2' }
   // On Market — show NEW badge if listed within last 7 days
   const listedAt = new Date(listedAtIso)
   const isNew = Date.now() - listedAt.getTime() <= 7 * DAY_MS
@@ -16,12 +18,14 @@ export function computeBadge(listedAtIso, status) {
 
 export function statusToClass(status) {
   const map = {
-    'On Market':      'on-market',
-    'Coming Soon':    'coming-soon',
-    'Under Contract': 'under-contract',
-    'Sold':           'sold',
-    'Off Market':     'off-market',
-    'Withdrawn':      'withdrawn',
+    'On Market':          'on-market',
+    'Coming Soon':        'coming-soon',
+    'Under Construction': 'under-construction',
+    'Ready Built':        'ready-built',
+    'Under Contract':     'under-contract',
+    'Sold':               'sold',
+    'Off Market':         'off-market',
+    'Withdrawn':          'withdrawn',
   }
   return map[status] ?? 'off-market'
 }

--- a/supabase/migrations/0016_expand_property_enums.sql
+++ b/supabase/migrations/0016_expand_property_enums.sql
@@ -1,0 +1,46 @@
+-- Phase 8.4: expand property TYPE + STATUS enums for AU real-estate categories
+--
+-- Pure addition — existing rows always satisfy the new constraints. No data
+-- migration needed (unlike 0006 which renamed 'Under Offer' -> 'Under Contract').
+--
+-- TYPE additions: Unit, Duplex, Studio, Penthouse, Land, Acreage / Rural,
+--   Granny Flat, Retirement Living, NDIS SDA Home, Off-the-Plan,
+--   House and Land Package, 10/90 One-Part Contract
+--
+-- STATUS additions: Under Construction, Ready Built
+
+-- 1. TYPE
+ALTER TABLE properties DROP CONSTRAINT IF EXISTS properties_type_check;
+ALTER TABLE properties ADD CONSTRAINT properties_type_check
+  CHECK (type IN (
+    'House',
+    'Townhouse',
+    'Apartment',
+    'Villa',
+    'Unit',
+    'Duplex',
+    'Studio',
+    'Penthouse',
+    'Land',
+    'Acreage / Rural',
+    'Granny Flat',
+    'Retirement Living',
+    'NDIS SDA Home',
+    'Off-the-Plan',
+    'House and Land Package',
+    '10/90 One-Part Contract'
+  ));
+
+-- 2. STATUS
+ALTER TABLE properties DROP CONSTRAINT IF EXISTS properties_status_check;
+ALTER TABLE properties ADD CONSTRAINT properties_status_check
+  CHECK (status IN (
+    'On Market',
+    'Coming Soon',
+    'Under Construction',
+    'Ready Built',
+    'Under Contract',
+    'Sold',
+    'Off Market',
+    'Withdrawn'
+  ));


### PR DESCRIPTION
…date

Boss flagged that the current TYPE + STATUS lists are too narrow for the agency's deal flow. He named a few examples (10/90 contract, house+land, under construction, ready built, NDIS SDA); user asked for a curated AU-focused expansion. "Extra is better than missing."

Enums (single source of truth = src/constants/enums.js):

TYPE — 4 -> 16:
  + Unit, Duplex, Studio, Penthouse, Land, Acreage / Rural, Granny Flat, Retirement Living, NDIS SDA Home, Off-the-Plan, House and Land Package, 10/90 One-Part Contract

STATUS — 6 -> 8:
  + Under Construction, Ready Built

Consolidation refactor — kill drift between form/filter/toolbar arrays that caused enums.js to fall out of sync after Phase 7:
  - PropertiesForm imports PROPERTY_TYPES + PROPERTY_STATUSES
  - filterDefinitions.js derives property options via .map (customer options untouched — different ordering convention)
  - PropertiesToolbar STATUS_GROUPS derived from PROPERTY_STATUSES with a colour-token lookup table

Visual + DB:
  - migration 0016 expands both CHECK constraints (pure addition)
  - tokens.css adds .status-badge.under-construction (warm tone) and .ready-built (success tone) -- some hue sharing with existing statuses; label disambiguates
  - property.js computeBadge + statusToClass handle the 2 new statuses

Layout polish (form was already tight at 4 cols; new longer values broke the row):
  - .grid-4 -> 2fr 2fr 1fr 1fr so type + status get the room
  - "Price (max, optional)" -> "Price (max)" so the label doesn't wrap
  - AddPropertyDialog max-width 640 -> 704 (+10%)