### PR TITLE
Phase 8.5: per-property PDF brochure storage

### DIFF
--- a/Bold_Vision_CRM/src/components/base/AppIcon.vue
+++ b/Bold_Vision_CRM/src/components/base/AppIcon.vue
@@ -51,6 +51,7 @@ const ICONS = {
   logout:   ['M10 18H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h5', 'm16 16 4-4-4-4', 'M20 12H10'],
   search:   ['M11 19a8 8 0 1 0 0-16 8 8 0 0 0 0 16Z', 'm21 21-4.35-4.35'],
   grid:     ['M4 4h7v7H4z', 'M13 4h7v7h-7z', 'M4 13h7v7H4z', 'M13 13h7v7h-7z'],
+  document: ['M14 3H7a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V8z', 'M14 3v5h5', 'M9 13h6', 'M9 17h4'],
 }
 
 const props = defineProps({

--- a/Bold_Vision_CRM/src/components/properties/PropertyBrochure.vue
+++ b/Bold_Vision_CRM/src/components/properties/PropertyBrochure.vue
@@ -1,0 +1,142 @@
+<template>
+  <div class="brochure-btn-wrap">
+    <v-menu offset="6" :close-on-content-click="true">
+      <template #activator="{ props: menuProps }">
+        <button
+          v-bind="menuProps"
+          type="button"
+          class="btn btn-ghost"
+          :disabled="busy"
+        >
+          <AppIcon name="document" :size="14" />
+          {{ hasBrochure ? 'Brochure' : 'Add brochure' }}
+          <AppIcon name="chevron" :size="12" class="brochure-btn-caret" />
+        </button>
+      </template>
+
+      <v-list density="compact" class="brochure-menu">
+        <template v-if="hasBrochure">
+          <v-list-item @click="onView">
+            <template #prepend><AppIcon name="eye" :size="14" /></template>
+            <v-list-item-title>View PDF</v-list-item-title>
+          </v-list-item>
+          <v-list-item @click="triggerFilePicker">
+            <template #prepend><AppIcon name="plus" :size="14" /></template>
+            <v-list-item-title>Replace</v-list-item-title>
+          </v-list-item>
+          <v-list-item @click="onDelete" class="brochure-menu__delete">
+            <template #prepend><AppIcon name="x" :size="14" /></template>
+            <v-list-item-title>Delete</v-list-item-title>
+          </v-list-item>
+        </template>
+        <template v-else>
+          <v-list-item @click="triggerFilePicker">
+            <template #prepend><AppIcon name="plus" :size="14" /></template>
+            <v-list-item-title>Upload PDF</v-list-item-title>
+          </v-list-item>
+        </template>
+      </v-list>
+    </v-menu>
+
+    <input
+      ref="fileInput"
+      type="file"
+      accept="application/pdf"
+      style="display: none"
+      @change="onFileChange"
+    />
+  </div>
+</template>
+
+<script setup>
+import { ref, computed } from 'vue'
+import AppIcon from '../base/AppIcon.vue'
+import {
+  uploadPropertyBrochure,
+  removePropertyBrochure,
+  getBrochureSignedUrl,
+} from '../../services/mediaService'
+import { useFeedback } from '../../composables/useFeedback'
+import { ValidationError } from '../../utils/validators'
+
+const props = defineProps({
+  propertyId: { type: String, required: true },
+  brochurePath: { type: String, default: null },
+})
+
+const emit = defineEmits(['update:brochurePath'])
+
+const { notifySuccess, notifyError } = useFeedback()
+
+const fileInput = ref(null)
+const busy = ref(false)
+
+const hasBrochure = computed(() => !!props.brochurePath)
+
+function triggerFilePicker() {
+  fileInput.value?.click()
+}
+
+async function onFileChange(e) {
+  const file = e.target.files?.[0]
+  if (fileInput.value) fileInput.value.value = ''
+  if (!file) return
+
+  busy.value = true
+  try {
+    const newPath = await uploadPropertyBrochure(props.propertyId, file)
+    emit('update:brochurePath', newPath)
+    notifySuccess('Brochure uploaded')
+  } catch (e) {
+    const msg = e instanceof ValidationError
+      ? Object.values(e.fields)[0]
+      : (e.message || 'Upload failed')
+    notifyError(msg)
+  } finally {
+    busy.value = false
+  }
+}
+
+async function onView() {
+  if (!props.brochurePath) return
+  busy.value = true
+  try {
+    const url = await getBrochureSignedUrl(props.brochurePath)
+    window.open(url, '_blank', 'noopener,noreferrer')
+  } catch (e) {
+    notifyError(e.message || 'Could not open brochure')
+  } finally {
+    busy.value = false
+  }
+}
+
+async function onDelete() {
+  if (!props.brochurePath) return
+  if (!window.confirm('Delete this brochure? You can upload a new one any time.')) return
+
+  busy.value = true
+  try {
+    await removePropertyBrochure(props.propertyId)
+    emit('update:brochurePath', null)
+    notifySuccess('Brochure deleted')
+  } catch (e) {
+    notifyError(e.message || 'Delete failed')
+  } finally {
+    busy.value = false
+  }
+}
+</script>
+
+<style scoped>
+.brochure-btn-wrap { display: inline-flex; }
+.brochure-btn-caret { opacity: 0.6; margin-left: 2px; }
+
+.brochure-menu :deep(.v-list-item) {
+  min-height: 36px;
+  font-size: 13.5px;
+  color: var(--text);
+  cursor: pointer;
+}
+.brochure-menu :deep(.v-list-item:hover) { background: var(--surface-2); }
+.brochure-menu__delete :deep(.v-list-item-title) { color: var(--hot-ink); }
+</style>

--- a/Bold_Vision_CRM/src/constants/propertyDefaults.js
+++ b/Bold_Vision_CRM/src/constants/propertyDefaults.js
@@ -22,6 +22,7 @@ export function createEmptyPropertyDraft() {
     houseSizeSqm: null,
     houseSize: '',
     mainPhoto: '',
+    brochurePath: null,
     gallery: [],
     highlights: [],
     amenities: [],

--- a/Bold_Vision_CRM/src/services/mediaService.js
+++ b/Bold_Vision_CRM/src/services/mediaService.js
@@ -1,7 +1,8 @@
 import { supabase } from './supabase'
-import { validatePhotoFile, ValidationError } from '../utils/validators'
+import { validatePhotoFile, validateBrochureFile, ValidationError } from '../utils/validators'
 
 const BUCKET = { photo: 'property-photos', floorplan: 'property-floorplans' }
+const BROCHURE_BUCKET = 'property-brochures'
 const SIGNED_URL_TTL = 3600
 
 // Simple in-memory cache so repeated renders don't re-request the same URL.
@@ -83,6 +84,81 @@ export async function listPropertyMedia(propertyId) {
     .order('sort_order', { ascending: true })
   if (error) throw error
   return data ?? []
+}
+
+// ── Brochure (PDF, single file per property) ─────────────────────────────────
+// Stored in the `property-brochures` bucket; the storage path lives directly
+// on properties.brochure_path (no separate table — one brochure per property).
+
+export async function uploadPropertyBrochure(propertyId, file) {
+  const err = validateBrochureFile(file)
+  if (err) throw new ValidationError({ file: err })
+
+  const { data: { user } } = await supabase.auth.getUser()
+  const path = `${user.id}/${propertyId}/${Date.now()}.pdf`
+
+  const { error: uploadError } = await supabase.storage
+    .from(BROCHURE_BUCKET)
+    .upload(path, file, { contentType: 'application/pdf', upsert: false })
+  if (uploadError) throw uploadError
+
+  // Read existing brochure path so we can delete the previous file after the
+  // new one is committed to properties.brochure_path.
+  const { data: existing } = await supabase
+    .from('properties')
+    .select('brochure_path')
+    .eq('id', propertyId)
+    .single()
+
+  const { error: updateError } = await supabase
+    .from('properties')
+    .update({ brochure_path: path })
+    .eq('id', propertyId)
+  if (updateError) {
+    // Compensating delete: row never got the new path, so the storage object
+    // is orphaned — clean it up.
+    await supabase.storage.from(BROCHURE_BUCKET).remove([path])
+    throw updateError
+  }
+
+  if (existing?.brochure_path && existing.brochure_path !== path) {
+    await supabase.storage.from(BROCHURE_BUCKET).remove([existing.brochure_path])
+    urlCache.delete(existing.brochure_path)
+  }
+
+  return path
+}
+
+export async function removePropertyBrochure(propertyId) {
+  const { data: row, error: fetchError } = await supabase
+    .from('properties')
+    .select('brochure_path')
+    .eq('id', propertyId)
+    .single()
+  if (fetchError) throw fetchError
+  if (!row?.brochure_path) return
+
+  const { error: updateError } = await supabase
+    .from('properties')
+    .update({ brochure_path: null })
+    .eq('id', propertyId)
+  if (updateError) throw updateError
+
+  await supabase.storage.from(BROCHURE_BUCKET).remove([row.brochure_path])
+  urlCache.delete(row.brochure_path)
+}
+
+export async function getBrochureSignedUrl(storagePath) {
+  const cached = urlCache.get(storagePath)
+  if (cached && cached.expiresAt > Date.now() + 60_000) return cached.url
+
+  const { data, error } = await supabase.storage
+    .from(BROCHURE_BUCKET)
+    .createSignedUrl(storagePath, SIGNED_URL_TTL)
+  if (error) throw error
+
+  urlCache.set(storagePath, { url: data.signedUrl, expiresAt: Date.now() + SIGNED_URL_TTL * 1000 })
+  return data.signedUrl
 }
 
 // Generates short-TTL signed URLs for the property's media, suitable for

--- a/Bold_Vision_CRM/src/services/propertiesService.js
+++ b/Bold_Vision_CRM/src/services/propertiesService.js
@@ -65,6 +65,7 @@ function mapRowToProperty(row) {
     houseSizeSqm,
     houseSize: formatSqm(houseSizeSqm),
     mainPhoto: row.main_photo_path ?? null,
+    brochurePath: row.brochure_path ?? null,
     photos: (row.property_photos ?? [])
       .filter((p) => p.kind === 'photo')
       .sort((a, b) => a.sort_order - b.sort_order)

--- a/Bold_Vision_CRM/src/utils/validators.js
+++ b/Bold_Vision_CRM/src/utils/validators.js
@@ -57,9 +57,11 @@ export const LIMITS = Object.freeze({
   assessmentNote:     { max: 5000 },
   photoSizeBytes:     { max: 10 * 1024 * 1024 },
   photoBatch:         { max: 20 },
+  brochureSizeBytes:  { max: 25 * 1024 * 1024 },
 })
 
 const PHOTO_MIME = new Set(['image/jpeg', 'image/png', 'image/webp'])
+const BROCHURE_MIME = new Set(['application/pdf'])
 
 // ── Atomic validators ───────────────────────────────────────────────────────
 
@@ -344,6 +346,15 @@ export function validatePhotoFile(file) {
   if (!file) return 'No file'
   if (!PHOTO_MIME.has(file.type)) return 'Only JPEG, PNG, or WebP images allowed'
   if (file.size > LIMITS.photoSizeBytes.max) return 'File must be 10 MB or smaller'
+  return null
+}
+
+// Brochure (PDF) upload pre-checks. Bucket policy is the final net; this
+// catches issues at the UI layer with friendlier errors.
+export function validateBrochureFile(file) {
+  if (!file) return 'No file'
+  if (!BROCHURE_MIME.has(file.type)) return 'Only PDF files are allowed'
+  if (file.size > LIMITS.brochureSizeBytes.max) return 'File must be 25 MB or smaller'
   return null
 }
 

--- a/Bold_Vision_CRM/src/views/PropertyDetailsView.vue
+++ b/Bold_Vision_CRM/src/views/PropertyDetailsView.vue
@@ -110,6 +110,11 @@
           <button class="btn btn-primary" @click="broadcastOpen = true">
             <AppIcon name="chat" :size="14" /> Broadcast
           </button>
+          <PropertyBrochure
+            :property-id="id"
+            :brochure-path="original?.brochurePath ?? null"
+            @update:brochure-path="onBrochureChanged"
+          />
         </div>
       </div>
     </div>
@@ -274,6 +279,7 @@ import { usePropertyStore } from '../stores/propertyStore'
 import { createEmptyPropertyDraft } from '../constants/propertyDefaults'
 import { useSignedUrl } from '../composables/useSignedUrl'
 import PropertyForm from '../components/properties/PropertiesForm.vue'
+import PropertyBrochure from '../components/properties/PropertyBrochure.vue'
 import PropertyInterestsPanel from '../components/properties/PropertyInterestsPanel.vue'
 import BroadcastPanel from '../components/properties/BroadcastPanel.vue'
 import PhotoLightbox from '../components/properties/PhotoLightbox.vue'
@@ -472,6 +478,13 @@ async function onHeroFileInputChange(e) {
 onMounted(() => {
   if (id) propertyStore.fetchProperty(id)
 })
+
+// Brochure is updated by the PropertyBrochure component via its own service
+// calls; the DB write has already landed when this fires. Re-fetch so
+// `original.brochurePath` reflects the new value.
+async function onBrochureChanged() {
+  if (id) await propertyStore.fetchProperty(id)
+}
 
 // ── photo handlers ───────────────────────────────────────────
 async function handleAdd(files, kind) {

--- a/docs/PHASE10-MIGRATION.md
+++ b/docs/PHASE10-MIGRATION.md
@@ -1,0 +1,390 @@
+# Phase 10 — V1 Company Migration (Migration Day)
+
+> **Status as of writing (2026-05-19):** Phase 9 complete. V1 proven on personal Vercel + personal Supabase. Real Telegram broadcast went end-to-end. Ready for company migration.
+
+**Goal:** put V1 onto company-owned infrastructure at `https://crm.boldvision.com.au` with zero ties to personal accounts. After this, personal Vercel + personal Supabase become disposable.
+
+**Total time:** ~2 focused hours of active work + DNS propagation wait + ~1 week observation before decommission.
+
+**Total recurring cost:** ~$70–78 AUD/month (see breakdown below).
+
+**Block out one quiet afternoon.** Don't squeeze between meetings — distractions cause copy-paste errors with API keys.
+
+---
+
+## Cost summary
+
+### Recurring (monthly)
+
+| Item | USD | AUD (~) | Notes |
+|---|---|---|---|
+| Supabase Pro (1 project) | $25 | ~$39 | 8GB DB, 100GB storage, 250GB bandwidth, daily backups, 7-day PITR. Usage over limits is metered separately. |
+| Vercel Pro (1 seat) | $20 | ~$31 | Per seat. Hobby is non-commercial per TOS — must upgrade. |
+| Workspace user (Business Starter) | — | $8.40 | Per added user. Skip if repurposing existing user. |
+| **Subtotal — with new Workspace user** | $45 USD + $8.40 AUD | **~$78/mo AUD** | |
+| **Subtotal — repurposing existing user** | $45 USD | **~$70/mo AUD** | |
+
+### One-time
+
+| Item | AUD (~) | Notes |
+|---|---|---|
+| YubiKey 5 NFC (optional) | $80 | Hardware 2FA for root identity. TOTP via Authenticator app is acceptable substitute. |
+| Domain | $0 | Already own `boldvision.com.au`. |
+| Data migration (boss's Word/PDF docs) | $15–30 in LLM API | Separate effort, after V1 is live. |
+
+**FX caveat:** USD→AUD shown at ~1.55. Bank typically adds 2–3% FX margin. Negligible at this scale.
+
+### Workspace user — repurpose vs new
+
+**Recommendation: create new `it@boldvision.com.au`.** Reasons:
+
+1. **Audit cleanliness** — the identity owning Supabase + Vercel + GitHub + Telegram bot should have zero history of being someone else.
+2. **Old data baggage** — renaming a Workspace user keeps their Gmail, Drive, Calendar attached.
+3. **Alias confusion (30–90 days)** — renamed account keeps old email as forwarding alias by default.
+4. **Cost is small** vs the full stack ($8.40/mo is ~11% of total).
+
+**Counter: if dormant accounts exist, delete them while you're in admin.** Each suspended/deleted user saves $8.40/mo. Check with boss first — sometimes "dormant" accounts get used quarterly for specific things (Xero, contracts).
+
+---
+
+## Pre-flight (do this BEFORE migration day, ~30 min)
+
+These 3 things have no time pressure. Doing them in advance means migration day is just "click through the list."
+
+- [ ] **Set up a password manager folder called "Bold Vision IT"** — 1Password, Bitwarden, or Apple Keychain all work. Every credential, token, and bot ID created during migration goes here. **Never paste these in chat with Claude.**
+- [ ] **Decide on Workspace email** — recommended: `it@boldvision.com.au`.
+- [ ] **Decide on GitHub org name** — recommended: `BoldVision`. Could be `bold-vision-properties` if taken. Doesn't affect URLs (Vercel domain is what users see).
+- [ ] **(Optional but recommended)** Order a YubiKey 5 NFC (~$80 AUD) for hardware 2FA on the Workspace root account.
+
+---
+
+## Migration day — Phases A–I in order
+
+---
+
+### Phase A — Create Workspace user (15 min)
+
+**Why:** All production SaaS gets owned by a dedicated company identity. If you ever hand the CRM to an IT intern or leave the business, that identity transfers cleanly. **Guard like the master key.**
+
+**Your job:**
+
+1. Sign in to https://admin.google.com as existing Workspace super-admin
+2. **Directory → Users → Add new user**
+3. Username: `it@boldvision.com.au`
+4. Set a random 20+ char password (1Password "Generate" → save under "Bold Vision IT")
+5. Recovery email: your personal Gmail
+6. After creation, sign out of admin, sign in once as the new `it@` user to confirm credentials work
+7. **Enable 2FA** for the `it@` account:
+   - TOTP via Authenticator app (acceptable)
+   - **Hardware key via YubiKey** (recommended — register under **Account → Security → 2-Step Verification → Add security key**)
+
+**Save to password manager:**
+- `it@boldvision.com.au` password
+- Recovery codes (Google gives 10 backup codes — save all)
+
+**You're done when:** you can sign in to admin.google.com as `it@boldvision.com.au` and pass 2FA.
+
+**Cost:** +$8.40 AUD/mo (extra Workspace user).
+
+---
+
+### Phase B — Create company GitHub org (10 min)
+
+**Why:** CRM source lives here. Separate from personal `Sakada-lim/CRM-Project`. Personal repo stays as local archive.
+
+**Your job:**
+
+1. Open a fresh browser session (different from personal GitHub login — incognito works)
+2. Go to https://github.com/signup
+3. Sign up with **email = `it@boldvision.com.au`** (verify via Workspace inbox)
+4. Username: e.g. `boldvision-it`
+5. **Enable 2FA on the new GitHub user** — Settings → Password & authentication → Two-factor authentication → YubiKey or Authenticator app
+6. Top-right `+` icon → **New organization**
+7. Pick **Free plan** (upgrade to Team later if needed)
+8. Org name: **`BoldVision`** (or `bold-vision-properties` if taken — tell Claude which)
+9. Billing email: `it@boldvision.com.au`
+10. Skip "invite members" — single owner for now
+11. **Org Settings → Authentication security → Require 2FA for everyone in the organization**
+
+**Don't create the repo yet — Phase C does that as part of the squash push.**
+
+**Save to password manager:**
+- GitHub username + password
+- 2FA recovery codes
+
+**You're done when:** the org exists at `github.com/BoldVision` and you're the sole owner.
+
+---
+
+### Phase C — Squash V1 + push to company repo (15 min — Claude does most)
+
+**Why:** Personal repo has 30+ commits across 8 phases. Company repo should start clean with a single `v1.0` commit. Personal repo stays as audit archive.
+
+**Together — Claude runs commands, you watch:**
+
+Claude will:
+
+1. **Secrets scan** on personal repo — make sure no production tokens leaked into git history. If anything sensitive shows up, rewrite history before pushing.
+2. **Create an orphan `v1-release` branch** off current `main`
+3. **Squash everything** into one commit: `v1.0 — Bold Vision CRM initial release`
+4. **Add the company repo as a new remote** (`company`)
+5. **Push** the orphan branch to `BoldVision/crm:main`
+
+**Your job — after the push:**
+
+1. Open `github.com/BoldVision/crm`
+2. Verify the commit lands as the only commit on `main`
+3. **Settings → Branches → Add branch protection rule** for `main`:
+   - ✅ Require pull request before merging
+   - ✅ Require at least 1 approval
+   - ✅ Dismiss stale approvals on push
+   - ❌ Disallow force pushes
+4. Confirm `main` is default branch
+
+**Don't push personal repo anywhere new** — keep as local archive.
+
+**You're done when:** `github.com/BoldVision/crm` has exactly 1 commit on a protected `main` branch.
+
+---
+
+### Phase D — New Supabase project + migrations (30 min)
+
+**Why:** Personal Supabase is Free-tier (no daily backups, no PITR). Production needs Pro for safety.
+
+**Your job:**
+
+1. Open https://supabase.com → sign up with `it@boldvision.com.au` (or sign in if account exists)
+2. **New organization** "Bold Vision" → **Pro plan** → add credit card (Stripe checkout)
+3. **New project:**
+   - Name: `bold-vision-crm-prod`
+   - Region: **Sydney (ap-southeast-2)** ← critical for AU latency
+   - DB password: generate 20+ chars in password manager
+4. Wait ~2 minutes for provisioning
+5. **Settings to verify:**
+   - **Database → Tables → Settings → "Automatically expose new tables"** → **OFF**
+   - **Authentication → Providers → Email** → enable email/password
+6. **Authentication → URL Configuration:**
+   - Site URL: `https://crm.boldvision.com.au`
+   - Redirect URLs: add both `https://crm.boldvision.com.au` AND the eventual Vercel preview URL (get in Phase G; come back here then)
+7. **Authentication → Attack Protection → Prevent use of leaked passwords → ON** (Pro-only — was deferred on personal account)
+8. **SQL Editor → New query** → apply migrations in order **0001 through 0017** (17 files in `supabase/migrations/`). Paste each separately, click **Run**, wait for "Success" before next. Don't bulk-paste — error in any one is harder to diagnose.
+9. **Storage → New bucket:**
+   - `property-photos` — Public OFF, file size limit 10 MB, MIME `image/jpeg,image/png,image/webp`
+   - `property-floorplans` — same settings
+   - `property-brochures` — Public OFF, file size limit 25 MB, MIME `application/pdf`
+10. **Settings → API** → record (needed in Phases F + G):
+    - **Project URL:** `https://<new-project-ref>.supabase.co`
+    - **anon public key** (`eyJ...` JWT — safe to expose, goes in client bundle)
+    - **service_role secret key** (`eyJ...` — server-only, **NEVER paste in chat**)
+
+**Save to password manager:**
+- DB password
+- service_role key (separately labeled — never confuse with anon)
+
+**You're done when:** all 17 migrations applied + 3 storage buckets exist + auth settings configured.
+
+**Cost:** +$38 AUD/mo (Pro plan).
+
+---
+
+### Phase E — New Telegram bot (10 min)
+
+**Why:** Personal bot becomes dev/test. Production gets fresh identity so customers see "@BoldVisionPropertiesBot" not personal one.
+
+**Your job:**
+
+1. Open Telegram → message **@BotFather**
+2. `/newbot`
+3. Display name: **"Bold Vision Properties"**
+4. Username: **`BoldVisionPropertiesBot`** (must end in `bot`; pick another suffix if taken — e.g. `BoldVisionRealEstateBot`)
+5. BotFather replies with the token — **copy to password manager only**, do not paste in chat
+6. `/setdescription` → "Property updates from Bold Vision Properties"
+7. `/setabouttext` → short bio
+8. `/setuserpic` → upload Bold Vision logo
+9. `/setjoingroups` → **Disable** (broadcast model is DM-only)
+10. Generate a 64-char webhook secret. On Windows PowerShell run:
+    ```powershell
+    -join (1..32 | %{ '{0:x2}' -f (Get-Random -Max 256) })
+    ```
+    Save to password manager.
+
+**Save to password manager:**
+- Bot token
+- Webhook secret
+
+**You're done when:** you can find `@BoldVisionPropertiesBot` in Telegram search and `/start` it (won't reply yet — webhook isn't registered).
+
+---
+
+### Phase F — Deploy edge functions to new Supabase (20 min)
+
+**Why:** New Supabase needs the edge functions to send broadcasts + receive webhooks.
+
+**Your job (with Claude coaching through each):**
+
+1. **Supabase Dashboard (new project) → Edge Functions → Create new function** named exactly **`send-telegram`**. Paste contents of `supabase/functions/send-telegram/index.ts` from the repo. Click Deploy.
+2. **Repeat for `telegram-webhook`** — paste `supabase/functions/telegram-webhook/index.ts`. Deploy.
+3. **Project Settings → Edge Functions → Secrets** → add three rows (don't paste these values in chat — get from password manager):
+   - `TELEGRAM_BOT_TOKEN` = new bot token from Phase E
+   - `TELEGRAM_WEBHOOK_SECRET` = new webhook secret from Phase E
+   - `ALLOWED_ORIGINS` = `https://crm.boldvision.com.au` (add Vercel URL after Phase G)
+4. **Edge Functions → `send-telegram` → Settings → Verify JWT → ON**
+5. **Edge Functions → `telegram-webhook` → Settings → Verify JWT → OFF** (Telegram doesn't send JWTs; secret-token header authenticates)
+6. **Register the webhook** — one-line curl from Git Bash or PowerShell. Replace `NEW_BOT_TOKEN`, `NEW_SUPABASE_REF`, `NEW_WEBHOOK_SECRET` with real values:
+   ```bash
+   curl -o resp.json -X POST "https://api.telegram.org/botNEW_BOT_TOKEN/setWebhook" -H "Content-Type: application/json" -d '{"url":"https://NEW_SUPABASE_REF.supabase.co/functions/v1/telegram-webhook","secret_token":"NEW_WEBHOOK_SECRET"}'; cat resp.json; echo; rm resp.json
+   ```
+   Expected: `{"ok":true,"result":true,"description":"Webhook was set"}`
+
+**You're done when:** both functions deployed, secrets configured, webhook returns `"ok":true`.
+
+---
+
+### Phase G — Vercel project (Pro tier) (15 min)
+
+**Why:** Vercel Hobby (current free tier) is non-commercial per TOS. Pro is production tier.
+
+**Your job:**
+
+1. Open https://vercel.com → sign in (or create account) as `it@boldvision.com.au`
+2. **Create team "Bold Vision"** → **Pro plan** ($20 USD/seat/month)
+3. **Settings → Git → Install GitHub App** → on the `BoldVision` org → grant access to **just the `crm` repo**
+4. **Add New → Project → Import** the `crm` repo
+5. **Configure exactly as in Phase 9** — except env vars now point at NEW Supabase:
+   - Framework: **Vite**
+   - Root Directory: **`Bold_Vision_CRM`**
+   - Environment Variables (Production + Preview):
+     - `VITE_SUPABASE_URL` = new Supabase project URL from Phase D
+     - `VITE_SUPABASE_ANON_KEY` = new Supabase anon key from Phase D
+6. Deploy. First build ~2 minutes.
+7. **Grab the `.vercel.app` URL** (e.g. `crm-bold-vision.vercel.app`) — tell Claude what it is
+8. **Open the URL** → verify login screen renders (same smoke test as Phase 9 Step 4)
+
+**Critical follow-up:** go back to **Supabase Phase F step 3** → update `ALLOWED_ORIGINS` to include both `https://crm.boldvision.com.au` AND the `.vercel.app` URL, comma-separated:
+```
+https://crm.boldvision.com.au,https://crm-bold-vision.vercel.app
+```
+
+**You're done when:** Vercel `.vercel.app` URL loads the app + you can sign up a test user and verify the email lands.
+
+**Cost:** +$30 AUD/mo (Pro plan).
+
+---
+
+### Phase H — Wire DNS for `crm.boldvision.com.au` (10 min + 5–30 min propagation)
+
+**Why:** Customer-facing URL. Until DNS resolves, users hit `.vercel.app`.
+
+**Determine DNS host first.** From Git Bash:
+```bash
+dig boldvision.com.au NS +short
+```
+Nameservers reveal where DNS lives:
+- `ns-cloud-*.googledomains.com` → Google Cloud DNS (manage in Workspace admin → Domains)
+- `dns*.squarespace.com` → Squarespace
+- Cloudflare → Cloudflare dashboard
+
+**Your job:**
+
+1. Vercel project → **Settings → Domains → Add** → enter `crm.boldvision.com.au`
+2. Vercel shows the target CNAME value (typically `cname.vercel-dns.com`). **Copy exactly.**
+3. Open DNS host's control panel
+4. Add a **CNAME** record:
+   - Name/Host: `crm`
+   - Value/Target: `cname.vercel-dns.com` (exact string Vercel gave)
+   - TTL: 3600 (default)
+5. Save
+6. Wait 5–30 min (rarely up to 24h). Refresh Vercel's Domains page — green checkmark appears when DNS resolves.
+7. SSL cert auto-provisions via Let's Encrypt within ~1 minute of DNS resolving.
+8. Open `https://crm.boldvision.com.au` in a fresh browser → should be the app.
+
+**You're done when:** `https://crm.boldvision.com.au` loads the login page with a valid cert.
+
+---
+
+### Phase I — Production smoke tests (30–45 min)
+
+**Why:** Final gate before declaring done. Anything broken here = block, fix, re-test.
+
+**Run these in order at `https://crm.boldvision.com.au`:**
+
+| # | Test | Pass criteria |
+|---|---|---|
+| 1 | Sign up the agent account (use real boss email or a dedicated one) | Verification email arrives from new Supabase domain |
+| 2 | Sign in | Lands on dashboard |
+| 3 | Sign in with `?redirect=https://evil.com` | Ignored; lands on `/` (H14 safeRedirect) |
+| 4 | Create a test property (`NDIS SDA Home`, `Under Construction`) | Saves; new badge renders correctly |
+| 5 | Create a test customer (with phone number) | Saves; duplicate-detection works |
+| 6 | Trigger duplicate-detection by trying to add another customer with same phone | Blocks |
+| 7 | Open assessment form on the test customer | N/A toggles work; three-state nav works |
+| 8 | Upload a photo to the test property | Photo renders via signed URL |
+| 8b | Upload a PDF brochure to the test property | "View" opens it in new tab; "Replace" swaps it; "Delete" removes it |
+| 9 | Enroll a Telegram test account via the bot | `/start <token>` in DM → customer's `telegram_chat_id` populates |
+| 10 | Send a Telegram broadcast to the test customer | Message arrives on test phone |
+| 11 | Delete the test customer (typed `CONFIRM` gate) | Works |
+| 12 | Sign out + sign back in | Auth lifecycle clean |
+| 13 | Hard-refresh on `/customers/<id>` | Loads directly (SPA rewrite) |
+| 14 | Browser DevTools Network tab → check response headers on root | HSTS, CSP, X-Frame-Options DENY all present |
+| 15 | Browser DevTools Console → no errors after navigation | Clean |
+
+**Anything that fails → tell Claude. Don't proceed to Phase J with a known issue.**
+
+**You're done when:** all 15 pass.
+
+---
+
+## Phase J — Decommission personal infra (schedule for ~1 week LATER)
+
+**Why the wait:** if anything subtly breaks in the first week (env var typo, edge case in a workflow), the personal stack is your fallback. After a week of clean production = safe to delete.
+
+**One week after Phase I passes:**
+
+1. **Personal Supabase project** → Dashboard → Project Settings → General → **Pause project** (free + reversible). Delete a week after pause if nothing else depends on it.
+2. **Personal Vercel project** → Delete (Settings → General → bottom).
+3. **Personal GitHub repo** (`Sakada-lim/CRM-Project`) → keep as private archive. **Don't push it anywhere new.** It's the audit-trail of how V1 was built.
+4. **Old Telegram bot** → keep. Re-purpose as future dev/test bot when next needed. Re-register webhook at a future dev Supabase.
+
+---
+
+## Critical artifacts at end of P10
+
+By end of migration day, all owned by `it@boldvision.com.au`:
+
+- [ ] Workspace user with 2FA enabled
+- [ ] `BoldVision/crm` private repo, branch-protected, 1 commit
+- [ ] `bold-vision-crm-prod` Supabase project (Pro, Sydney) with all 16 migrations + 2 buckets + edge fns deployed
+- [ ] New Telegram bot `@BoldVisionPropertiesBot` with webhook registered
+- [ ] Vercel `crm` project, prod branch `main`, auto-deploys from GitHub
+- [ ] `crm.boldvision.com.au` CNAME → Vercel with SSL
+- [ ] Password manager folder "Bold Vision IT" populated with every credential
+
+---
+
+## Roles split
+
+| Phase | Your time | Claude's time |
+|---|---|---|
+| Pre-flight | 30 min | — |
+| A (Workspace user) | 15 min | — |
+| B (GitHub org) | 10 min | — |
+| C (squash + push) | 5 min watching | 15 min running git |
+| D (Supabase Pro + migrations) | 30 min | guiding |
+| E (Telegram bot) | 10 min | — |
+| F (deploy edge fns) | 20 min | guiding |
+| G (Vercel + env vars) | 15 min | guiding |
+| H (DNS + propagation) | 10 min + wait | — |
+| I (smoke tests) | 30–45 min | diagnosing if anything fails |
+| J (decommission) | 5 min | — |
+
+**Total active time on migration day: ~2 hours + DNS wait.**
+
+---
+
+## When ready
+
+Reply to Claude with:
+- **"go pre-flight"** → Claude waits while you do the 3 prep items. Tell Claude when done.
+- **"go migration day"** → if pre-flight is already done, start at Phase A.
+- **"questions first"** → ask anything before committing.
+
+Once you start, recommend going A→I in a single sitting. Stopping mid-way and resuming hours later is OK but slightly riskier (you lose context).

--- a/supabase/migrations/0017_property_brochures.sql
+++ b/supabase/migrations/0017_property_brochures.sql
@@ -1,0 +1,40 @@
+-- Phase 8.5: per-property PDF brochure storage
+--
+-- Adds a nullable text column on properties to hold a single brochure's
+-- Supabase Storage path (in the new `property-brochures` bucket).
+--
+-- Singular relationship: one brochure per property. If multi-doc support is
+-- ever needed (Section 32, contracts, etc.), promote to a property_documents
+-- table at that point.
+--
+-- The bucket itself is created via Supabase Dashboard, not SQL, because
+-- bucket policies are managed there. This file just creates the storage RLS
+-- policies that gate access to objects inside the bucket.
+
+ALTER TABLE properties
+  ADD COLUMN IF NOT EXISTS brochure_path TEXT;
+
+-- Storage RLS policies for property-brochures. Same pattern as the
+-- property-photos/property-floorplans policies in 0001_init.sql:
+-- file path must start with the authenticated user's UID, e.g.
+--   <auth.uid()>/<property_id>/<timestamp>.pdf
+
+drop policy if exists "agent_upload_brochures" on storage.objects;
+create policy "agent_upload_brochures" on storage.objects
+  for insert to authenticated
+  with check (bucket_id = 'property-brochures' and split_part(name,'/',1) = auth.uid()::text);
+
+drop policy if exists "agent_read_brochures" on storage.objects;
+create policy "agent_read_brochures" on storage.objects
+  for select to authenticated
+  using (bucket_id = 'property-brochures' and split_part(name,'/',1) = auth.uid()::text);
+
+drop policy if exists "agent_update_brochures" on storage.objects;
+create policy "agent_update_brochures" on storage.objects
+  for update to authenticated
+  using (bucket_id = 'property-brochures' and split_part(name,'/',1) = auth.uid()::text);
+
+drop policy if exists "agent_delete_brochures" on storage.objects;
+create policy "agent_delete_brochures" on storage.objects
+  for delete to authenticated
+  using (bucket_id = 'property-brochures' and split_part(name,'/',1) = auth.uid()::text);


### PR DESCRIPTION
Adds a single PDF brochure per property. Surfaced as a "Brochure" ghost button next to the primary Broadcast button on PropertyDetailsView; opens a dropdown menu with Upload / View / Replace / Delete actions.

Storage layout:
  - new bucket: property-brochures (PDF-only, 25 MB cap)
  - new column: properties.brochure_path (singular relationship -- one brochure per property; promote to property_documents table if/when multi-doc support is needed)
  - new component: PropertyBrochure.vue (button + v-menu activator around all brochure actions, wraps existing mediaService calls)

mediaService additions:
  - uploadPropertyBrochure: validates PDF + size client-side, uploads to bucket, updates properties.brochure_path with compensating storage delete on row update failure
  - removePropertyBrochure: nulls column, removes storage object
  - getBrochureSignedUrl: 1h signed URL (cached), opened in new tab
  - brochurePath included in mapRowToProperty (read path); NOT in mapPropertyToRow so form save can't accidentally wipe it
  - re-fetches property on brochure change so store stays in sync

DB (migration 0017):
  - ALTER TABLE properties ADD brochure_path TEXT
  - storage RLS policies: insert/select/update/delete on property-brochures bucket, scoped to files under the user's UID prefix (mirrors the property-photos/floorplans pattern from 0001)
  - all idempotent (IF NOT EXISTS on column, DROP+CREATE on policies)

Other:
  - validateBrochureFile (utils/validators.js): pdf + 25 MB
  - new "document" icon in AppIcon.vue (Lucide file-text shape)
  - propertyDefaults: brochurePath: null
  - docs/PHASE10-MIGRATION.md: bumped migration count 16 -> 17, added third bucket to Phase D, added smoke test row 8b